### PR TITLE
[codex] Refactor agent flow and improve tool coverage

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,20 @@
-AGENT_API_SECRET=your-secret-here
-# Optional for local browser access to the protected /api/agent route.
-# In local dev, set this to the same value as AGENT_API_SECRET.
-NEXT_PUBLIC_AGENT_API_SECRET=your-secret-here
+# Required: server-side model access.
+DEEPSEEK_API_KEY=your-deepseek-api-key
+
+# Optional: DeepSeek-compatible API settings.
+DEEPSEEK_BASE_URL=https://api.deepseek.com
+DEEPSEEK_MODEL=deepseek-v4-flash
+
+# Required: protects POST /api/agent on the server.
+AGENT_API_SECRET=replace-with-a-long-random-local-secret
+
+# Local dev only: this value is exposed to the browser because of NEXT_PUBLIC.
+# Set it to the same value as AGENT_API_SECRET only for local development.
+NEXT_PUBLIC_AGENT_API_SECRET=replace-with-the-same-local-secret
+
+# Optional: absolute folder the agent may inspect and draft edits inside.
+# Leave empty to use data/workspace.
+# AGENT_WORKSPACE_ROOT=C:\path\to\project
+
 # Optional: set this only if GitHub CLI is not available on PATH.
-GH_PATH=C:\path\to\gh.exe
+# GH_PATH=C:\path\to\gh.exe

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ pnpm-debug.log*
 # local dev runtime output
 /.next-dev
 /test-results
+/.test-dist
 
 # system files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 <h1 align="center">THRUSH</h1>
 
 <p align="center">
-  A self-hosted SWE agent that thinks before it acts —<br>
+  A self-hosted SWE agent that thinks before it acts<br>
   plans tasks, calls tools to inspect your codebase,<br>
   and requires explicit approval before writing a single line.
 </p>
 
 <p align="center">
-  <code>Next.js 15</code> · <code>TypeScript</code> · <code>DeepSeek</code> · <code>Playwright</code> · <code>SSE</code>
+  <code>Next.js 15</code> | <code>TypeScript</code> | <code>DeepSeek</code> | <code>Playwright</code> | <code>SSE</code>
 </p>
 
 ---
@@ -20,7 +20,7 @@
 
 | Capability | Detail |
 |---|---|
-| Agent loop | `Perceive → Think → Act` streamed to the UI in real time |
+| Agent loop | `Perceive -> Think -> Act` streamed to the UI in real time |
 | Tool calling | Files, search, web, Git, GitHub issues, shell allowlist |
 | Draft approval | Nothing writes to disk until you explicitly approve |
 | Browser tools | Playwright-powered page reading and clicking |
@@ -30,33 +30,77 @@
 
 ## Quickstart
 
+1. Install dependencies:
+
 ```bash
 npm install
-npm run dev
 ```
 
-Add to `.env.local`:
+2. Copy the environment example:
+
+```powershell
+Copy-Item .env.local.example .env.local
+```
+
+3. Edit `.env.local` and set at least these values:
 
 ```bash
-DEEPSEEK_API_KEY=your_key
-DEEPSEEK_BASE_URL=https://api.deepseek.com
-DEEPSEEK_MODEL=deepseek-v4-flash
-AGENT_API_SECRET=your-secret
+DEEPSEEK_API_KEY=your-deepseek-api-key
+AGENT_API_SECRET=replace-with-a-long-random-local-secret
+NEXT_PUBLIC_AGENT_API_SECRET=replace-with-the-same-local-secret
+```
+
+4. Start the app:
+
+```bash
+npm run dev
 ```
 
 Open `http://localhost:3000`.
 
-To point at a real project:
+## Point at a real project
+
+By default, Thrush only sees `data/workspace`.
+
+To let it inspect a real local project, set `AGENT_WORKSPACE_ROOT` in `.env.local`:
 
 ```bash
-AGENT_WORKSPACE_ROOT=C:\your\project npm run dev
+AGENT_WORKSPACE_ROOT=C:\your\project
 ```
+
+Then restart `npm run dev`.
+
+## Environment variables
+
+| Name | Required | Purpose |
+|---|---:|---|
+| `DEEPSEEK_API_KEY` | Yes | API key used by the server-side agent loop |
+| `DEEPSEEK_BASE_URL` | No | DeepSeek-compatible API base URL; defaults to `https://api.deepseek.com` |
+| `DEEPSEEK_MODEL` | No | Model name; defaults to `deepseek-v4-flash` |
+| `AGENT_API_SECRET` | Yes | Server-side Bearer token required by `/api/agent` |
+| `NEXT_PUBLIC_AGENT_API_SECRET` | Local dev only | Browser-side token used by the local UI to call `/api/agent` |
+| `AGENT_WORKSPACE_ROOT` | No | Absolute folder path the agent is allowed to inspect and draft edits inside |
+| `GH_PATH` | No | Absolute path to `gh.exe` if GitHub CLI is not on `PATH` |
+
+## Security notes
+
+- Do not commit `.env.local`; it is ignored by Git.
+- Do not put real production secrets in `NEXT_PUBLIC_AGENT_API_SECRET`. Any `NEXT_PUBLIC_*` value is shipped to the browser, so users can inspect it.
+- The current browser UI auth is suitable for local development only. For production, put the UI behind real user authentication and keep the server token server-only.
+- `AGENT_WORKSPACE_ROOT` is the main file boundary. The file tools reject paths outside this folder.
 
 ## Tool list
 
-`click_page` · `git_inspect` · `list_files` · `read_file` · `read_page` · `replace_text` · `safe_command` · `search_text` · `web_search` · `write_file`
+`click_page` | `git_inspect` | `list_files` | `read_file` | `read_page` | `replace_text` | `safe_command` | `search_text` | `web_search` | `write_file`
+
+## Known gaps
+
+- Test coverage is still narrow. The current `test` script focuses on `safe_command`; agent loop, API route, file tools, and browser tools still need tests.
+- File reading supports line windows; file listing is still one folder at a time, with no tree summary tool yet.
+- Draft storage is in memory, so a server restart loses pending drafts.
+- `NEXT_PUBLIC_AGENT_API_SECRET` makes local UI auth simple, but it is not a production-grade auth design.
 
 ## Status
 
-> **Small real agent, not yet full platform.**
-> Works as a serious prototype. Missing: persistent sessions, multi-user isolation, test suite, production deployment.
+> Small real agent, not yet a full platform.
+> Works as a serious prototype. Missing: persistent sessions, multi-user isolation, test suite, and production deployment hardening.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,17 @@
+import { FlatCompat } from "@eslint/eslintrc";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    ignores: [".next/**", ".next-dev/**", ".test-dist/**", "next-env.d.ts", "node_modules/**"],
+  },
+];
+
+export default eslintConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "mini-codex-mvp",
+  "name": "thrush-swe-agent",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mini-codex-mvp",
+      "name": "thrush-swe-agent",
       "version": "0.1.0",
       "dependencies": {
         "next": "^15.3.0",
@@ -15,6 +15,7 @@
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
+        "@eslint/eslintrc": "^3.3.5",
         "@playwright/test": "^1.60.0",
         "@types/node": "^22.15.30",
         "@types/react": "^19.0.10",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint .",
+    "test": "tsc -p tsconfig.test.json && node --test .test-dist/test/safe-command.test.js"
   },
   "dependencies": {
     "next": "^15.3.0",
@@ -16,6 +17,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.5",
     "@playwright/test": "^1.60.0",
     "@types/node": "^22.15.30",
     "@types/react": "^19.0.10",

--- a/src/components/chat/chat-shell.tsx
+++ b/src/components/chat/chat-shell.tsx
@@ -49,7 +49,6 @@ const loadingSteps: AgentStep[] = [
   },
 ];
 
-const MAX_CONTEXT_MESSAGES = 8;
 const thinkingFragments = ["top", "right", "bottom", "left"] as const;
 const agentApiSecret = process.env.NEXT_PUBLIC_AGENT_API_SECRET?.trim();
 
@@ -208,7 +207,7 @@ export function ChatShell() {
     try {
       const payload: AgentRequest = {
         task: cleanTask,
-        messages: nextMessages.slice(-MAX_CONTEXT_MESSAGES),
+        messages: nextMessages,
         sessionContext,
         stream: true,
       };

--- a/src/lib/agent/agent-response.ts
+++ b/src/lib/agent/agent-response.ts
@@ -1,0 +1,77 @@
+import type {
+  AgentResponse,
+  AgentStep,
+  AgentStreamEvent,
+  ChatMessage,
+} from "@/types/agent";
+
+export type RunAgentOptions = {
+  onEvent?: (event: AgentStreamEvent) => void | Promise<void>;
+};
+
+export function createStep(id: string, title: string, detail: string): AgentStep {
+  return {
+    id,
+    title,
+    detail,
+    status: "done",
+  };
+}
+
+export function createMessage(
+  content: string,
+  reasoningContent?: string | null,
+): ChatMessage {
+  return {
+    id: `assistant-${Date.now()}`,
+    role: "assistant",
+    content,
+    ...(reasoningContent ? { reasoning_content: reasoningContent } : {}),
+  };
+}
+
+function cloneSteps(steps: AgentStep[]) {
+  return steps.map((step) => ({ ...step }));
+}
+
+export async function emitAgentEvent(
+  onEvent: RunAgentOptions["onEvent"],
+  event: AgentStreamEvent,
+) {
+  if (!onEvent) {
+    return;
+  }
+
+  await onEvent(event);
+}
+
+export async function emitStepsSnapshot(
+  steps: AgentStep[],
+  onEvent: RunAgentOptions["onEvent"],
+) {
+  await emitAgentEvent(onEvent, {
+    type: "steps",
+    steps: cloneSteps(steps),
+  });
+}
+
+export async function finishAgentRun(
+  response: AgentResponse,
+  onEvent: RunAgentOptions["onEvent"],
+  includeSteps: boolean,
+) {
+  if (includeSteps) {
+    await emitStepsSnapshot(response.steps, onEvent);
+  }
+
+  await emitAgentEvent(onEvent, {
+    type: "message",
+    message: response.message,
+  });
+  await emitAgentEvent(onEvent, {
+    type: "done",
+    sessionContext: response.sessionContext,
+  });
+
+  return response;
+}

--- a/src/lib/agent/conversation-context.ts
+++ b/src/lib/agent/conversation-context.ts
@@ -1,0 +1,150 @@
+import type { AgentSessionContext, ChatMessage } from "@/types/agent";
+import { callModelForText } from "@/lib/agent/model-client";
+
+export const MAX_CONTEXT_MESSAGES = 8;
+
+const MAX_CONVERSATION_SUMMARY_CHARS = 1600;
+
+function normalizeConversationMessages(messages: ChatMessage[] | undefined, task: string) {
+  if (!messages?.length) {
+    return [];
+  }
+
+  const normalizedMessages = messages
+    .filter((message) => {
+      if (message.role !== "user" && message.role !== "assistant") {
+        return false;
+      }
+
+      return message.content.trim().length > 0;
+    })
+    .map((message) => ({
+      ...message,
+      content: message.content.trim(),
+    }));
+
+  if (normalizedMessages.length === 0) {
+    return [];
+  }
+
+  const lastMessage = normalizedMessages.at(-1);
+  return lastMessage?.role === "user" && lastMessage.content === task.trim()
+    ? normalizedMessages.slice(0, -1)
+    : normalizedMessages;
+}
+
+export function normalizeSessionContext(
+  sessionContext: AgentSessionContext | undefined,
+): AgentSessionContext {
+  if (!sessionContext) {
+    return {};
+  }
+
+  return {
+    conversationSummary: sessionContext.conversationSummary?.trim() || null,
+    lastListedDirectoryPath: sessionContext.lastListedDirectoryPath?.trim() || null,
+    lastReadFilePath: sessionContext.lastReadFilePath?.trim() || null,
+    lastToolInput: sessionContext.lastToolInput?.trim() || null,
+    lastToolName: sessionContext.lastToolName?.trim() || null,
+    pendingDraft: sessionContext.pendingDraft
+      ? {
+          ...sessionContext.pendingDraft,
+          content: sessionContext.pendingDraft.content,
+          id: sessionContext.pendingDraft.id.trim(),
+          path: sessionContext.pendingDraft.path.trim(),
+        }
+      : null,
+  };
+}
+
+export function formatConversationForModel(messages: ChatMessage[]) {
+  if (messages.length === 0) {
+    return "No recent conversation.";
+  }
+
+  return messages
+    .map((message) => `${message.role.toUpperCase()}: ${message.content}`)
+    .join("\n\n");
+}
+
+export function formatConversationSummaryForModel(sessionContext: AgentSessionContext) {
+  return sessionContext.conversationSummary?.trim() || "No older conversation summary.";
+}
+
+function trimConversationSummary(summary: string) {
+  const cleanSummary = summary.trim();
+
+  if (cleanSummary.length <= MAX_CONVERSATION_SUMMARY_CHARS) {
+    return cleanSummary;
+  }
+
+  return cleanSummary.slice(0, MAX_CONVERSATION_SUMMARY_CHARS).trim();
+}
+
+async function summarizeOldConversation(
+  model: string,
+  existingSummary: string | null | undefined,
+  oldConversation: ChatMessage[],
+) {
+  if (oldConversation.length === 0) {
+    return existingSummary?.trim() || null;
+  }
+
+  const response = await callModelForText(model, [
+    {
+      role: "system",
+      content: [
+        "You compress old chat history for a coding agent.",
+        "Write a short working-memory summary, not a transcript.",
+        "Keep durable user requests, project facts, file paths, decisions, pending constraints, and unresolved tasks.",
+        "Drop greetings, repeated content, and details that are already superseded.",
+        "If the existing summary overlaps with the old messages, merge and deduplicate it.",
+        `Stay under ${MAX_CONVERSATION_SUMMARY_CHARS} characters.`,
+      ].join("\n"),
+    },
+    {
+      role: "user",
+      content: [
+        "Existing summary:",
+        existingSummary?.trim() || "(none)",
+        "",
+        "Old messages to fold into the summary:",
+        formatConversationForModel(oldConversation),
+      ].join("\n"),
+    },
+  ]);
+
+  return trimConversationSummary(response.content) || null;
+}
+
+export async function prepareConversationContext(
+  model: string,
+  messages: ChatMessage[] | undefined,
+  task: string,
+  sessionContext: AgentSessionContext,
+) {
+  const conversation = normalizeConversationMessages(messages, task);
+  const recentConversation = conversation.slice(-MAX_CONTEXT_MESSAGES);
+  const oldConversation = conversation.slice(0, -MAX_CONTEXT_MESSAGES);
+
+  if (oldConversation.length === 0) {
+    return {
+      recentConversation,
+      sessionContext,
+    };
+  }
+
+  const conversationSummary = await summarizeOldConversation(
+    model,
+    sessionContext.conversationSummary,
+    oldConversation,
+  );
+
+  return {
+    recentConversation,
+    sessionContext: {
+      ...sessionContext,
+      conversationSummary,
+    },
+  };
+}

--- a/src/lib/agent/direct-tool-plans.ts
+++ b/src/lib/agent/direct-tool-plans.ts
@@ -1,0 +1,530 @@
+import { parseTagBlock } from "@/lib/agent/tool-args";
+import {
+  createSyntheticToolCallId,
+  type DirectToolPlan,
+} from "@/lib/agent/tool-run-types";
+import type { PlannedToolCall } from "@/lib/agent/model-client";
+
+function extractUrlFromTask(task: string) {
+  const match = task.match(/https?:\/\/[^\s)>"']+|www\.[^\s)>"']+/i);
+  return match?.[0]?.trim() ?? null;
+}
+
+function cleanClickTargetLabel(rawLabel: string) {
+  return rawLabel
+    .trim()
+    .replace(/^["'“”‘’]+|["'“”‘’]+$/gu, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function deriveClickSelectorFromTask(task: string) {
+  if (/\bclick\s+the\s+first\s+link\b/i.test(task) || /点击第一个链接/u.test(task)) {
+    return "a";
+  }
+
+  if (/\bclick\s+the\s+first\s+button\b/i.test(task) || /点击第一个按钮/u.test(task)) {
+    return "button";
+  }
+
+  const englishLinkMatch = task.match(/\bclick\s+(?:the\s+)?(.+?)\s+link\b/i);
+  if (englishLinkMatch?.[1]) {
+    const label = cleanClickTargetLabel(englishLinkMatch[1]);
+    if (label) {
+      return `text=${label}`;
+    }
+  }
+
+  const englishButtonMatch = task.match(/\bclick\s+(?:the\s+)?(.+?)\s+button\b/i);
+  if (englishButtonMatch?.[1]) {
+    const label = cleanClickTargetLabel(englishButtonMatch[1]);
+    if (label) {
+      return `text=${label}`;
+    }
+  }
+
+  const chineseLinkMatch = task.match(/点击(.+?)链接/u);
+  if (chineseLinkMatch?.[1]) {
+    const label = cleanClickTargetLabel(chineseLinkMatch[1]);
+    if (label) {
+      return `text=${label}`;
+    }
+  }
+
+  const chineseButtonMatch = task.match(/点击(.+?)按钮/u);
+  if (chineseButtonMatch?.[1]) {
+    const label = cleanClickTargetLabel(chineseButtonMatch[1]);
+    if (label) {
+      return `text=${label}`;
+    }
+  }
+
+  return null;
+}
+
+function deriveMaxCharsFromTask(task: string) {
+  const englishMatch = task.match(
+    /\b(?:around|about|roughly|only|just)?\s*(\d{2,4})\s*(?:characters|character|chars)\b/i,
+  );
+  if (englishMatch?.[1]) {
+    return Number(englishMatch[1]);
+  }
+
+  const chineseMatch = task.match(/(\d{2,4})\s*(?:字|字符)/u);
+  if (chineseMatch?.[1]) {
+    return Number(chineseMatch[1]);
+  }
+
+  return null;
+}
+
+export function deriveDirectClickToolCall(
+  task: string,
+): PlannedToolCall | null {
+  const url = extractUrlFromTask(task);
+  const selector = deriveClickSelectorFromTask(task);
+  const maxChars = deriveMaxCharsFromTask(task);
+
+  if (!url || !selector) {
+    return null;
+  }
+
+  return {
+    id: createSyntheticToolCallId(),
+    name: "click_page",
+    input:
+      maxChars === null
+        ? {
+            url,
+            selector,
+          }
+        : {
+            url,
+            selector,
+            max_chars: maxChars,
+          },
+  };
+}
+
+export function deriveDirectSafeCommandToolCall(
+  task: string,
+): DirectToolPlan | null {
+  const cleanTask = task.trim();
+
+  const asksForGitStatus =
+    /\bgit\s+status\b/i.test(cleanTask) ||
+    /(仓库状态|git状态|当前状态|工作区状态)/u.test(cleanTask);
+
+  if (asksForGitStatus) {
+    return {
+      id: createSyntheticToolCallId(),
+      name: "safe_command",
+      input: {
+        command: "git",
+        args: ["status"],
+      },
+    };
+  }
+
+  const asksForBuild =
+    /\bnpm\s+run\s+build\b/i.test(cleanTask) ||
+    /\bbuild\b/i.test(cleanTask) ||
+    /(构建|编译|跑一下构建|构建检查|验证构建|检查能不能构建)/u.test(cleanTask);
+
+  if (asksForBuild) {
+    return {
+      id: createSyntheticToolCallId(),
+      name: "safe_command",
+      input: {
+        command: "npm",
+        args: ["run", "build"],
+      },
+    };
+  }
+
+  const asksForTest =
+    /\bnpm\s+test\b/i.test(cleanTask) ||
+    /\btest\b/i.test(cleanTask) ||
+    /(测试|跑测试|执行测试|验证测试|检查测试)/u.test(cleanTask);
+
+  if (asksForTest) {
+    return {
+      id: createSyntheticToolCallId(),
+      name: "safe_command",
+      input: {
+        command: "npm",
+        args: ["test"],
+      },
+    };
+  }
+
+  return null;
+}
+
+export function deriveDirectGitInspectToolCall(
+  task: string,
+): DirectToolPlan | null {
+  const cleanTask = task.trim();
+  const asksForIssuePlan =
+    /(issue\s*(计划|execution\s*plan)|执行计划|改代码计划)/iu.test(cleanTask);
+  const issueDetailMatch =
+    cleanTask.match(/\bissue\s+#?(\d+)\b/i) ||
+    cleanTask.match(/issue\s*详情\s*#?(\d+)/iu) ||
+    cleanTask.match(/第\s*(\d+)\s*个\s*issue/iu) ||
+    cleanTask.match(/issue\s*(\d+)/iu);
+
+  if (asksForIssuePlan && issueDetailMatch?.[1]) {
+    return {
+      id: createSyntheticToolCallId(),
+      name: "git_inspect",
+      input: {
+        action: "issue_plan",
+        issue_number: Number(issueDetailMatch[1]),
+      },
+    };
+  }
+
+  if (issueDetailMatch?.[1]) {
+    return {
+      id: createSyntheticToolCallId(),
+      name: "git_inspect",
+      input: {
+        action: "issue_detail",
+        issue_number: Number(issueDetailMatch[1]),
+      },
+    };
+  }
+
+  const asksForIssueList =
+    /\bissues?\b/i.test(cleanTask) ||
+    /(issue 列表|issues 列表|当前 issue|仓库 issue|待办|问题列表)/iu.test(cleanTask);
+
+  if (asksForIssueList) {
+    return {
+      id: createSyntheticToolCallId(),
+      name: "git_inspect",
+      input: {
+        action: "issue_list",
+      },
+    };
+  }
+
+  const asksForRepoInfo =
+    /\brepo\b/i.test(cleanTask) ||
+    /(仓库信息|当前仓库|repo info|repository info|仓库详情|github 仓库信息)/iu.test(cleanTask);
+
+  if (asksForRepoInfo) {
+    return {
+      id: createSyntheticToolCallId(),
+      name: "git_inspect",
+      input: {
+        action: "repo_info",
+      },
+    };
+  }
+
+  const asksForTaskSubmit =
+    /\btask[_\s-]?submit\b/i.test(cleanTask) ||
+    /(任务提交|提交草稿|提交任务草稿|生成提交草稿)/u.test(cleanTask);
+
+  if (asksForTaskSubmit) {
+    return {
+      id: createSyntheticToolCallId(),
+      name: "git_inspect",
+      input: {
+        action: "task_submit",
+      },
+    };
+  }
+
+  const asksForPatchExport =
+    /\b(?:patch|patch\s+export|export\s+patch|diff\s+patch)\b/i.test(cleanTask) ||
+    /(导出补丁|补丁导出|生成补丁|输出补丁|补丁文本)/u.test(cleanTask);
+
+  if (asksForPatchExport) {
+    return {
+      id: createSyntheticToolCallId(),
+      name: "git_inspect",
+      input: {
+        action: "patch_export",
+      },
+    };
+  }
+
+  const asksForPrDraft =
+    /\bpr\b/i.test(cleanTask) ||
+    /(pr 草稿|pull request|拉取请求|合并请求|pr 文案|pr draft|帮我写 pr)/iu.test(cleanTask);
+
+  if (asksForPrDraft) {
+    return {
+      id: createSyntheticToolCallId(),
+      name: "git_inspect",
+      input: {
+        action: "pr_draft",
+      },
+    };
+  }
+
+  const asksForCommitMessage =
+    /\bcommit\s+message\b/i.test(cleanTask) ||
+    /(提交说明|提交信息|commit 文案|commit message|帮我写提交信息|帮我写 commit)/iu.test(cleanTask);
+
+  if (asksForCommitMessage) {
+    return {
+      id: createSyntheticToolCallId(),
+      name: "git_inspect",
+      input: {
+        action: "commit_message",
+      },
+    };
+  }
+
+  const asksForGithubEnv =
+    /\bgh\b/i.test(cleanTask) ||
+    /(github|remote|origin).{0,12}(连接|连上|环境|状态|检查|配置)/iu.test(cleanTask) ||
+    /(有没有\s*remote|有没有\s*github\s*remote|能不能用\s*gh|github\s*登录|gh\s*登录)/iu.test(
+      cleanTask,
+    );
+
+  if (asksForGithubEnv) {
+    return {
+      id: createSyntheticToolCallId(),
+      name: "git_inspect",
+      input: {
+        action: "github_env",
+      },
+    };
+  }
+
+  const asksForGitSummary =
+    /(?:git|change|diff|status)\s+summary/i.test(cleanTask) ||
+    /(变更总结|改动总结|总结改动|总结变更|git总结|git 摘要|change summary)/iu.test(cleanTask);
+
+  if (asksForGitSummary) {
+    return {
+      id: createSyntheticToolCallId(),
+      name: "git_inspect",
+      input: {
+        action: "summary",
+      },
+    };
+  }
+
+  const asksForGitDiff =
+    /\bgit\s+diff\b/i.test(cleanTask) ||
+    /(git\s*diff|仓库差异|改动差异|变更差异|查看差异|看看差异)/iu.test(cleanTask);
+
+  if (asksForGitDiff) {
+    return {
+      id: createSyntheticToolCallId(),
+      name: "git_inspect",
+      input: {
+        action: "diff",
+      },
+    };
+  }
+
+  const asksForGitStatus =
+    /\bgit\s+status\b/i.test(cleanTask) ||
+    /(git\s*状态|仓库状态|工作区状态|改动状态|查看状态|看看状态)/iu.test(cleanTask);
+
+  if (asksForGitStatus) {
+    return {
+      id: createSyntheticToolCallId(),
+      name: "git_inspect",
+      input: {
+        action: "status",
+      },
+    };
+  }
+
+  const asksWhetherGitRepo =
+    /\bgit\s+(repo|repository)\b/i.test(cleanTask) ||
+    /(是不是|是否|算不算|当前目录|这个目录|这个项目).{0,12}(git\s*仓库|git\s*repo|git\s*repository)/iu.test(
+      cleanTask,
+    ) ||
+    /(git\s*仓库|git\s*repo|git\s*repository).{0,12}(吗|有没有|情况|状态|检查)/iu.test(
+      cleanTask,
+    );
+
+  if (!asksWhetherGitRepo) {
+    return null;
+  }
+
+  return {
+    id: createSyntheticToolCallId(),
+    name: "git_inspect",
+    input: {
+      action: "check_repo",
+    },
+  };
+}
+
+export function derivePastedIssuePlanToolCall(
+  task: string,
+): DirectToolPlan | null {
+  const cleanTask = task.trim();
+  const hasPastedIssueText =
+    /(?:^|\n)\s*title\s*:/i.test(cleanTask) &&
+    /(?:^|\n)\s*body\s*:/i.test(cleanTask);
+  const mentionsIssue = /\bissue\b/i.test(cleanTask);
+
+  if (!hasPastedIssueText || !mentionsIssue) {
+    return null;
+  }
+
+  return {
+    id: createSyntheticToolCallId(),
+    name: "git_inspect",
+    input: {
+      action: "issue_plan",
+      issue_text: cleanTask,
+    },
+  };
+}
+
+function stripLeadingMatch(text: string, patterns: RegExp[]) {
+  let nextText = text.trim();
+
+  for (const pattern of patterns) {
+    const updated = nextText.replace(pattern, "").trim();
+    if (updated !== nextText) {
+      nextText = updated;
+    }
+  }
+
+  return nextText;
+}
+
+function stripTrailingMatch(text: string, patterns: RegExp[]) {
+  let nextText = text.trim();
+
+  for (const pattern of patterns) {
+    const updated = nextText.replace(pattern, "").trim();
+    if (updated !== nextText) {
+      nextText = updated;
+    }
+  }
+
+  return nextText;
+}
+
+export function deriveWebSearchQueryFromTask(task: string) {
+  const taggedQuery = parseTagBlock(task, "query");
+  if (taggedQuery) {
+    return taggedQuery;
+  }
+
+  let query = task.trim();
+
+  query = stripLeadingMatch(query, [
+    /^(?:请帮我|帮我|请你|请|麻烦你|麻烦)\s*/u,
+    /^(?:在网上|上网|在线)\s*/u,
+    /^(?:搜索一下|搜索|搜一下|搜一搜|搜搜|查一下|查一查|查查|查找|查询|找一下)\s*/u,
+    /^(?:关于|一下)\s*/u,
+    /^(?:please\s+)?(?:search|look up|find)\s+(?:for\s+)?/iu,
+  ]);
+
+  query = stripTrailingMatch(query, [
+    /[\u3002\uFF0C\uFF01\uFF1F,!.?]?\s*(?:并|然后|再)?\s*(?:把|将)?\s*(?:网页)?标题和链接(?:告诉我|给我|发我)?\s*$/u,
+    /[\u3002\uFF0C\uFF01\uFF1F,!.?]?\s*(?:只要|只需要)?\s*(?:网页)?标题和链接\s*$/u,
+    /[\u3002\uFF0C\uFF01\uFF1F,!.?]?\s*(?:告诉我|给我|发我|列出来)\s*$/u,
+    /\s*(?:and\s+)?(?:give|tell|show)\s+me\s+(?:the\s+)?title(?:s)?\s+and\s+link(?:s)?\s*$/iu,
+  ]);
+
+  query = query.replace(/^["'“”‘’\s]+|["'“”‘’\s]+$/gu, "").trim();
+
+  return query || task.trim();
+}
+
+function hasWhoSearchIntent(text: string) {
+  return /(?:是谁|什么人|谁啊|谁呀)/u.test(text);
+}
+
+function hasWhenSearchIntent(text: string) {
+  return /(?:什么时候|啥时候|何时|几点|几号|哪天|when|what\s+time|what\s+date)/iu.test(
+    text,
+  );
+}
+
+function hasEndSearchIntent(text: string) {
+  return /(?:结束|截止|end|ending|ends)/iu.test(text);
+}
+
+function hasStartSearchIntent(text: string) {
+  return /(?:开始|开幕|start|begin|opening)/iu.test(text);
+}
+
+function collapseSearchTerms(text: string) {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function appendSearchTerms(query: string, suffix: string) {
+  const normalizedQuery = collapseSearchTerms(query);
+
+  if (!normalizedQuery) {
+    return suffix;
+  }
+
+  if (normalizedQuery.toLowerCase().includes(suffix.toLowerCase())) {
+    return normalizedQuery;
+  }
+
+  return `${normalizedQuery} ${suffix}`;
+}
+
+export function deriveFocusedWebSearchQuery(task: string) {
+  const taggedQuery = parseTagBlock(task, "query");
+  if (taggedQuery) {
+    return taggedQuery;
+  }
+
+  const originalTask = task.trim();
+  const asksWho = hasWhoSearchIntent(originalTask);
+  const asksWhen = hasWhenSearchIntent(originalTask);
+  const asksEnd = hasEndSearchIntent(originalTask);
+  const asksStart = hasStartSearchIntent(originalTask);
+
+  let query = originalTask;
+
+  query = stripLeadingMatch(query, [
+    /^(?:请帮我|帮我|请你|请|麻烦你|麻烦)\s*/u,
+    /^(?:在网上|上网|在线)\s*/u,
+    /^(?:搜索一下|搜索|搜一下|搜一搜|搜搜|查一下|查一查|查查|查找|查询|找一下)\s*/u,
+    /^(?:关于|一下)\s*/u,
+    /^(?:please\s+)?(?:search|look up|find)\s+(?:for\s+)?/iu,
+  ]);
+
+  query = stripTrailingMatch(query, [
+    /[\u3002\uFF0C\uFF01\uFF1F,!.?]?\s*(?:并|然后|再)?\s*(?:把|将)?\s*(?:网页)?标题和链接(?:告诉我|给我|发我)?\s*$/u,
+    /[\u3002\uFF0C\uFF01\uFF1F,!.?]?\s*(?:只要|只需要)?\s*(?:网页)?标题和链接\s*$/u,
+    /[\u3002\uFF0C\uFF01\uFF1F,!.?]?\s*(?:告诉我|给我|发我|列出来)\s*$/u,
+    /\s*(?:and\s+)?(?:give|tell|show)\s+me\s+(?:the\s+)?title(?:s)?\s+and\s+link(?:s)?\s*$/iu,
+  ]);
+
+  query = collapseSearchTerms(
+    query
+      .replace(/[\u3002\uFF0C\uFF01\uFF1F,!.?]+/gu, " ")
+      .replace(/([\p{Script=Han}])在(?=[A-Za-z0-9])/gu, "$1 ")
+      .replace(/(?<=[\p{Script=Han}])(?=[A-Za-z0-9])/gu, " ")
+      .replace(/(?<=[A-Za-z0-9])(?=[\p{Script=Han}])/gu, " ")
+      .replace(
+        /(?:是谁|什么人|谁啊|谁呀|什么时候|啥时候|何时|几点|几号|哪天|什么时间|结束|截止|开始|开幕)/gu,
+        " ",
+      )
+      .replace(/\b(?:who|when|what\s+time|what\s+date)\b/giu, " ")
+      .replace(/[\u201c\u201d"'`\u2018\u2019]+/gu, " "),
+  );
+
+  if (asksWho) {
+    query = appendSearchTerms(query, "人物 简介");
+  } else if (asksWhen && asksEnd) {
+    query = appendSearchTerms(query, "结束时间");
+  } else if (asksWhen && asksStart) {
+    query = appendSearchTerms(query, "开始时间");
+  } else if (asksWhen) {
+    query = appendSearchTerms(query, "时间 日期");
+  }
+
+  return query || originalTask;
+}

--- a/src/lib/agent/draft-lifecycle.ts
+++ b/src/lib/agent/draft-lifecycle.ts
@@ -1,0 +1,319 @@
+import type { AgentResponse } from "@/types/agent";
+import {
+  applyPendingWriteDraft,
+  clearPendingWriteDraft,
+  getPendingWriteDraft,
+} from "@/lib/tools/pending-write";
+import {
+  createMessage,
+  createStep,
+} from "@/lib/agent/agent-response";
+import {
+  APPROVE_WRITE_COMMAND,
+  CANCEL_WRITE_COMMAND,
+} from "@/lib/agent/tool-run-types";
+
+type WriteCommand =
+  | {
+      type: "approve" | "cancel";
+      draftId: string | null;
+    }
+  | null;
+
+export type DraftLifecycleAction = "approve" | "cancel" | "continue";
+
+export function parseWriteCommand(task: string): WriteCommand {
+  const trimmedTask = task.trim();
+  const approveMatch = trimmedTask.match(/^APPROVE_WRITE(?:\s+(\S+))?$/i);
+  if (approveMatch) {
+    return {
+      type: "approve",
+      draftId: approveMatch[1] ?? null,
+    };
+  }
+
+  const cancelMatch = trimmedTask.match(/^CANCEL_WRITE(?:\s+(\S+))?$/i);
+  if (cancelMatch) {
+    return {
+      type: "cancel",
+      draftId: cancelMatch[1] ?? null,
+    };
+  }
+
+  return null;
+}
+
+export function parseDraftLifecycleAction(
+  task: string,
+): DraftLifecycleAction | null {
+  const trimmedTask = task.trim();
+
+  if (!trimmedTask) {
+    return null;
+  }
+
+  if (
+    /^(?:please\s+)?approve(?:\s|$)/i.test(trimmedTask) ||
+    /^(批准|确认写入|批准这个|批准刚才那个|确认这个draft|确认这个草稿|应用草稿|写入草稿)/u.test(
+      trimmedTask,
+    )
+  ) {
+    return "approve";
+  }
+
+  if (
+    /^(?:please\s+)?cancel(?:\s|$)/i.test(trimmedTask) ||
+    /^(取消|丢弃|丢掉|放弃|不要写了|取消这个|取消刚才那个)/u.test(
+      trimmedTask,
+    )
+  ) {
+    return "cancel";
+  }
+
+  if (
+    /^(?:please\s+)?continue(?:\s|$)/i.test(trimmedTask) ||
+    /^(继续|接着|继续上一步|继续刚才那个)/u.test(trimmedTask)
+  ) {
+    return "continue";
+  }
+
+  return null;
+}
+
+export function isAmbiguousDraftConfirmation(task: string) {
+  const trimmedTask = task.trim().toLowerCase();
+
+  return (
+    /^(ok|okay|yes|yep|go ahead|looks good|approved?)$/.test(trimmedTask) ||
+    /^(通过|好|行|可以|确认|没问题)$/.test(task.trim())
+  );
+}
+
+export async function handleWriteApproval(
+  task: string,
+): Promise<AgentResponse | null> {
+  const command = parseWriteCommand(task);
+
+  if (!command) {
+    return null;
+  }
+
+  if (!command.draftId) {
+    const commandName =
+      command.type === "approve" ? APPROVE_WRITE_COMMAND : CANCEL_WRITE_COMMAND;
+
+    return {
+      message: createMessage(
+        [
+          "A draft id is required.",
+          `Use the exact format: ${commandName} draft-123`,
+        ].join("\n"),
+      ),
+      sessionContext: {},
+      steps: [
+        createStep(
+          "perceive",
+          "Perceive",
+          "Read a write confirmation command from the user.",
+        ),
+        createStep(
+          "think",
+          "Think",
+          "Check whether the command includes a draft id.",
+        ),
+        createStep(
+          "act",
+          "Act",
+          "Stop here because the command was missing its draft id.",
+        ),
+      ],
+    };
+  }
+
+  if (command.type === "approve") {
+    const pendingDraft = getPendingWriteDraft();
+
+    if (!pendingDraft) {
+      return {
+        message: createMessage("There is no pending write draft to approve."),
+        sessionContext: {},
+        steps: [
+          createStep(
+            "perceive",
+            "Perceive",
+            "Read the approval command from the user.",
+          ),
+          createStep(
+            "think",
+            "Think",
+            "Check whether a pending write draft exists.",
+          ),
+          createStep(
+            "act",
+            "Act",
+            "No draft was waiting, so nothing was written.",
+          ),
+        ],
+      };
+    }
+
+    if (pendingDraft.id !== command.draftId) {
+      return {
+        message: createMessage(
+          [
+            "The draft id did not match the current pending draft.",
+            `Requested id: ${command.draftId}`,
+            `Current pending id: ${pendingDraft.id}`,
+          ].join("\n"),
+        ),
+        sessionContext: {
+          pendingDraft,
+        },
+        steps: [
+          createStep(
+            "perceive",
+            "Perceive",
+            `Read the approval command for draft "${command.draftId}".`,
+          ),
+          createStep(
+            "think",
+            "Think",
+            `Compare the requested id with the current pending draft id "${pendingDraft.id}".`,
+          ),
+          createStep(
+            "act",
+            "Act",
+            "Refuse the write because the draft id did not match.",
+          ),
+        ],
+      };
+    }
+
+    const appliedDraft = await applyPendingWriteDraft();
+
+    return {
+      message: createMessage(
+        [
+          "Write approved and saved.",
+          `Draft id: ${pendingDraft.id}`,
+          `Target path: ${pendingDraft.path}`,
+          "The draft has been written to disk.",
+        ].join("\n"),
+      ),
+      sessionContext: {
+        lastToolInput: pendingDraft.path,
+        lastToolName: "write_file",
+        pendingDraft: null,
+      },
+      steps: [
+        createStep(
+          "perceive",
+          "Perceive",
+          `Read the exact approval command "${APPROVE_WRITE_COMMAND} ${pendingDraft.id}".`,
+        ),
+        createStep(
+          "think",
+          "Think",
+          `Confirm that draft "${pendingDraft.id}" exists for "${pendingDraft.path}".`,
+        ),
+        createStep(
+          "act",
+          "Act",
+          `Write approved draft "${appliedDraft?.id ?? pendingDraft.id}" to "${appliedDraft?.path ?? pendingDraft.path}".`,
+        ),
+      ],
+    };
+  }
+
+  const pendingDraft = getPendingWriteDraft();
+
+  if (!pendingDraft) {
+    return {
+      message: createMessage("There is no pending write draft to discard."),
+      sessionContext: {},
+      steps: [
+        createStep(
+          "perceive",
+          "Perceive",
+          "Read the cancel command from the user.",
+        ),
+        createStep(
+          "think",
+          "Think",
+          "Check whether there is a pending draft to discard.",
+        ),
+        createStep(
+          "act",
+          "Act",
+          "Nothing was waiting, so nothing was cleared.",
+        ),
+      ],
+    };
+  }
+
+  if (pendingDraft.id !== command.draftId) {
+    return {
+      message: createMessage(
+        [
+          "The draft id did not match the current pending draft.",
+          `Requested id: ${command.draftId}`,
+          `Current pending id: ${pendingDraft.id}`,
+        ].join("\n"),
+      ),
+      sessionContext: {
+        pendingDraft,
+      },
+      steps: [
+        createStep(
+          "perceive",
+          "Perceive",
+          `Read the cancel command for draft "${command.draftId}".`,
+        ),
+        createStep(
+          "think",
+          "Think",
+          `Compare the requested id with the current pending draft id "${pendingDraft.id}".`,
+        ),
+        createStep(
+          "act",
+          "Act",
+          "Keep the draft because the cancel id did not match.",
+        ),
+      ],
+    };
+  }
+
+  clearPendingWriteDraft();
+
+  return {
+    message: createMessage(
+      [
+        "Draft discarded.",
+        `Draft id: ${pendingDraft.id}`,
+        `Target path: ${pendingDraft.path}`,
+      ].join("\n"),
+    ),
+    sessionContext: {
+      lastToolInput: pendingDraft.path,
+      lastToolName: "write_file",
+      pendingDraft: null,
+    },
+    steps: [
+      createStep(
+        "perceive",
+        "Perceive",
+        `Read the exact cancel command "${CANCEL_WRITE_COMMAND} ${pendingDraft.id}".`,
+      ),
+      createStep(
+        "think",
+        "Think",
+        `Confirm that draft "${pendingDraft.id}" is the one waiting to be discarded.`,
+      ),
+      createStep(
+        "act",
+        "Act",
+        `Clear draft "${pendingDraft.id}" for "${pendingDraft.path}" without writing it.`,
+      ),
+    ],
+  };
+}

--- a/src/lib/agent/issue-flow.ts
+++ b/src/lib/agent/issue-flow.ts
@@ -1,0 +1,403 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import type { PlannedToolCall } from "@/lib/agent/model-client";
+import {
+  getStringArg,
+  getToolPathReference,
+} from "@/lib/agent/tool-args";
+import {
+  createSyntheticToolCallId,
+  type ToolRun,
+} from "@/lib/agent/tool-run-types";
+import { getWorkspaceRoot } from "@/lib/tools/workspace-path";
+
+function taskLooksChinese(text: string) {
+  return /[\u4e00-\u9fff]/u.test(text);
+}
+
+function parseReportSection(
+  content: string,
+  sectionName: string,
+  nextSectionNames: string[],
+) {
+  const lines = content.split(/\r?\n/);
+  const startIndex = lines.findIndex(
+    (line) => line.trim() === `${sectionName}:`,
+  );
+
+  if (startIndex === -1) {
+    return null;
+  }
+
+  const collectedLines: string[] = [];
+
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    const trimmedLine = lines[index]?.trim();
+
+    if (nextSectionNames.some((name) => trimmedLine === `${name}:`)) {
+      break;
+    }
+
+    collectedLines.push(lines[index] ?? "");
+  }
+
+  const sectionContent = collectedLines.join("\n").trim();
+  return sectionContent && sectionContent !== "(none)" ? sectionContent : null;
+}
+
+export function parseGitInspectAction(content: string) {
+  const match = content.match(/^action:\s*(.+)$/m);
+  return match?.[1]?.trim() ?? null;
+}
+
+function extractIssueDetailFromGitInspectReport(content: string) {
+  return parseReportSection(content, "issue_detail", ["issue_list"]);
+}
+
+export function extractIssuePlanFromGitInspectReport(content: string) {
+  return parseReportSection(content, "issue_plan", ["repo_info"]);
+}
+
+function isStructuredIssueDetail(text: string) {
+  return /^#\d+\s+\[[A-Z]+\]\s+/m.test(text);
+}
+
+export function deriveIssuePlanToolCallFromToolRun(
+  toolRun: ToolRun,
+): PlannedToolCall | null {
+  if (toolRun.name !== "git_inspect" || !toolRun.result.ok) {
+    return null;
+  }
+
+  if (parseGitInspectAction(toolRun.result.content) !== "issue_detail") {
+    return null;
+  }
+
+  const issueDetail = extractIssueDetailFromGitInspectReport(
+    toolRun.result.content,
+  );
+
+  if (!issueDetail || !isStructuredIssueDetail(issueDetail)) {
+    return null;
+  }
+
+  return {
+    id: createSyntheticToolCallId(),
+    name: "git_inspect",
+    input: {
+      action: "issue_plan",
+      issue_text: issueDetail,
+    },
+  };
+}
+
+function extractBulletItems(sectionContent: string | null) {
+  if (!sectionContent) {
+    return [];
+  }
+
+  return sectionContent
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("- "))
+    .map((line) => line.slice(2).trim())
+    .filter(Boolean);
+}
+
+function looksLikeWorkspacePath(value: string) {
+  return /(?:[A-Za-z0-9_.-]+[\\/])+[A-Za-z0-9_.-]+|[A-Za-z0-9_.-]+\.(?:ts|tsx|js|jsx|json|md|css|scss|html)$/i.test(
+    value,
+  );
+}
+
+function getDefaultIssueSearchPath() {
+  const workspaceRoot = getWorkspaceRoot();
+  const candidatePath =
+    ["src", "app", "pages", "components", "lib"].find((candidate) =>
+      existsSync(path.join(workspaceRoot, candidate)),
+    ) ?? ".";
+
+  return candidatePath;
+}
+
+function extractIssuePlanCandidatePaths(issuePlan: string) {
+  return extractBulletItems(
+    parseReportSection(issuePlan, "Possible related files or modules", [
+      "Useful search keywords",
+    ]),
+  ).filter((item) => looksLikeWorkspacePath(item));
+}
+
+function extractIssuePlanKeywords(issuePlan: string) {
+  const keywordLines = extractBulletItems(
+    parseReportSection(issuePlan, "Useful search keywords", [
+      "Recommended first step",
+    ]),
+  );
+
+  if (keywordLines.length === 0) {
+    return [];
+  }
+
+  return keywordLines
+    .flatMap((line) => line.split(","))
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0 && item !== "(need manual triage)");
+}
+
+export function deriveIssueInvestigationToolCallFromToolRun(
+  toolRun: ToolRun,
+): PlannedToolCall | null {
+  if (toolRun.name !== "git_inspect" || !toolRun.result.ok) {
+    return null;
+  }
+
+  if (parseGitInspectAction(toolRun.result.content) !== "issue_plan") {
+    return null;
+  }
+
+  const issuePlan = extractIssuePlanFromGitInspectReport(
+    toolRun.result.content,
+  );
+
+  if (!issuePlan) {
+    return null;
+  }
+
+  const candidatePaths = extractIssuePlanCandidatePaths(issuePlan);
+  if (candidatePaths.length > 0) {
+    return {
+      id: createSyntheticToolCallId(),
+      name: "read_file",
+      input: {
+        path: candidatePaths[0],
+      },
+    };
+  }
+
+  const keywords = extractIssuePlanKeywords(issuePlan);
+  if (keywords.length > 0) {
+    return {
+      id: createSyntheticToolCallId(),
+      name: "search_text",
+      input: {
+        query: keywords[0],
+        path: getDefaultIssueSearchPath(),
+      },
+    };
+  }
+
+  return null;
+}
+
+function findLatestIssuePlanIndex(toolRuns: ToolRun[]) {
+  for (let index = toolRuns.length - 1; index >= 0; index -= 1) {
+    const toolRun = toolRuns[index];
+    if (
+      toolRun.name === "git_inspect" &&
+      toolRun.result.ok &&
+      parseGitInspectAction(toolRun.result.content) === "issue_plan" &&
+      extractIssuePlanFromGitInspectReport(toolRun.result.content)
+    ) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+export function getLatestIssuePlanText(toolRuns: ToolRun[]) {
+  const latestIssuePlanIndex = findLatestIssuePlanIndex(toolRuns);
+
+  if (latestIssuePlanIndex === -1) {
+    return null;
+  }
+
+  return extractIssuePlanFromGitInspectReport(
+    toolRuns[latestIssuePlanIndex]?.result.content ?? "",
+  );
+}
+
+export function isIssueDrivenReadForDraft(toolRuns: ToolRun[]) {
+  const latestToolRun = toolRuns.at(-1);
+
+  if (
+    !latestToolRun ||
+    latestToolRun.name !== "read_file" ||
+    !latestToolRun.result.ok
+  ) {
+    return false;
+  }
+
+  const latestIssuePlanIndex = findLatestIssuePlanIndex(toolRuns);
+  return latestIssuePlanIndex !== -1 && latestIssuePlanIndex < toolRuns.length - 1;
+}
+
+function extractIssueGoalFromPlan(issuePlan: string) {
+  const goalLines = extractBulletItems(
+    parseReportSection(issuePlan, "What this issue is trying to fix", [
+      "Possible related files or modules",
+    ]),
+  );
+
+  return goalLines[0] ?? "Need manual issue summary.";
+}
+
+function buildPreviewText(content: string, maxLines: number, maxChars: number) {
+  const preview = content
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim().length > 0)
+    .slice(0, maxLines)
+    .join("\n")
+    .trim();
+
+  if (!preview) {
+    return "(empty)";
+  }
+
+  if (preview.length <= maxChars) {
+    return preview;
+  }
+
+  return `${preview.slice(0, maxChars)}\n[preview truncated]`;
+}
+
+function parseSearchResultMatches(content: string) {
+  return content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => /^[^:\s][^:]*:\d+:\s/.test(line))
+    .map((line) => {
+      const match = line.match(/^(.*?):(\d+):\s*(.*)$/);
+      return match
+        ? {
+            path: match[1].trim(),
+            line: match[2].trim(),
+            snippet: match[3].trim(),
+          }
+        : null;
+    })
+    .filter(
+      (
+        item,
+      ): item is {
+        line: string;
+        path: string;
+        snippet: string;
+      } => item !== null,
+    );
+}
+
+export function formatIssueInvestigationAnswer(
+  goal: string,
+  toolRuns: ToolRun[],
+) {
+  const latestToolRun = toolRuns.at(-1);
+
+  if (!latestToolRun || !latestToolRun.result.ok) {
+    return null;
+  }
+
+  if (latestToolRun.name !== "read_file" && latestToolRun.name !== "search_text") {
+    return null;
+  }
+
+  const issuePlan = getLatestIssuePlanText(toolRuns);
+  const latestIssuePlanIndex = findLatestIssuePlanIndex(toolRuns);
+  if (!issuePlan || latestIssuePlanIndex >= toolRuns.length - 1) {
+    return null;
+  }
+
+  const issueGoal = extractIssueGoalFromPlan(issuePlan);
+  const isChinese = taskLooksChinese(goal);
+
+  if (latestToolRun.name === "read_file") {
+    const targetPath = getToolPathReference(latestToolRun.input) ?? "(unknown file)";
+    const preview = buildPreviewText(latestToolRun.result.content, 12, 900);
+
+    return isChinese
+      ? [
+          "第一步调查结果：",
+          `- 这个 issue 想解决：${issueGoal}`,
+          `- 当前优先怀疑位置：${targetPath}`,
+          "- 为什么先看这里：执行计划把它列成候选文件，所以先确认这里是不是问题发生点。",
+          "- 代码预览：",
+          preview,
+          "建议下一步：",
+          `- 继续围绕 ${targetPath} 里和 issue 相关的函数、条件分支或渲染位置缩小范围。`,
+          "- 确认最小改动点后，再决定用 replace_text 还是 write_file 准备改动草稿。",
+          "验证提醒：",
+          "- 保留 issue 里的复现方式，改完后走同一遍检查。",
+          "- 最后跑一次 npm run build。",
+        ].join("\n")
+      : [
+          "First investigation result:",
+          `- Issue goal: ${issueGoal}`,
+          `- Current likely edit target: ${targetPath}`,
+          "- Why this file first: the execution plan named it as a likely file, so this is the safest first inspection point.",
+          "- Code preview:",
+          preview,
+          "Recommended next step:",
+          `- Narrow the scope inside ${targetPath} to the specific function, branch, or render path tied to the issue.`,
+          "- Once the smallest edit point is clear, choose replace_text or write_file for the draft.",
+          "Validation reminder:",
+          "- Re-run the same issue scenario after the change.",
+          "- Run npm run build at the end.",
+        ].join("\n");
+  }
+
+  const matches = parseSearchResultMatches(latestToolRun.result.content);
+  const topMatches = matches.slice(0, 3);
+  const firstMatch = topMatches[0];
+  const searchedKeyword =
+    typeof latestToolRun.input === "string"
+      ? latestToolRun.input
+      : getStringArg(latestToolRun.input, "query") || "(unknown keyword)";
+  const preview =
+    topMatches.length > 0
+      ? topMatches
+          .map((match) => `- ${match.path}:${match.line}: ${match.snippet}`)
+          .join("\n")
+      : latestToolRun.result.content;
+
+  return isChinese
+    ? [
+        "第一步调查结果：",
+        `- 这个 issue 想解决：${issueGoal}`,
+        `- 当前优先搜索词：${searchedKeyword}`,
+        firstMatch
+          ? `- 当前更像改动入口的位置：${firstMatch.path}:${firstMatch.line}`
+          : "- 还没有找到明确的改动入口。",
+        "- 为什么先看这里：执行计划没有点名具体文件，所以先用关键词在代码里找落点。",
+        "- 搜索命中预览：",
+        preview,
+        "建议下一步：",
+        firstMatch
+          ? `- 先读 ${firstMatch.path}，确认这段命中是不是和 issue 描述的行为直接相关。`
+          : "- 换一个更具体的关键词，再搜一次。",
+        "- 定位到真正相关的文件后，再决定最小改动点。",
+        "验证提醒：",
+        "- 保留 issue 里的复现方式，改完后走同一遍检查。",
+        "- 最后跑一次 npm run build。",
+      ].join("\n")
+    : [
+        "First investigation result:",
+        `- Issue goal: ${issueGoal}`,
+        `- Current search keyword: ${searchedKeyword}`,
+        firstMatch
+          ? `- Current likely entry point: ${firstMatch.path}:${firstMatch.line}`
+          : "- No clear edit entry point has been found yet.",
+        "- Why start here: the plan did not name one exact file, so the safest first move is keyword search.",
+        "- Search preview:",
+        preview,
+        "Recommended next step:",
+        firstMatch
+          ? `- Read ${firstMatch.path} next and confirm whether that hit is directly tied to the issue behavior.`
+          : "- Try a more specific search keyword and search again.",
+        "- Once the real file is confirmed, narrow to the smallest edit point.",
+        "Validation reminder:",
+        "- Re-run the same issue scenario after the change.",
+        "- Run npm run build at the end.",
+      ].join("\n");
+}

--- a/src/lib/agent/model-client.ts
+++ b/src/lib/agent/model-client.ts
@@ -1,0 +1,201 @@
+import OpenAI from "openai";
+import type { ToolCallArgs } from "@/lib/tools/types";
+import { listTools } from "@/lib/tools/tool-registry";
+
+export type PlannedToolCall = {
+  id: string;
+  input: ToolCallArgs;
+  name: string;
+};
+
+export type ModelTextMessage = {
+  content: string;
+  reasoning_content?: string | null;
+};
+
+export type ModelToolMessage = {
+  assistantMessage: LlmMessage;
+  content: string | null;
+  toolCall: PlannedToolCall | null;
+};
+
+export type LlmMessage = {
+  role: "system" | "user" | "assistant" | "tool";
+  content?: string | Array<{ text?: string; type?: string }> | null;
+  reasoning_content?: string | null;
+  tool_call_id?: string;
+  tool_calls?: Array<{
+    id: string;
+    type: "function";
+    function: {
+      name: string;
+      arguments: string;
+    };
+  }>;
+};
+
+function createModelClient() {
+  const apiKey = process.env.DEEPSEEK_API_KEY;
+
+  if (!apiKey) {
+    throw new Error("Missing DEEPSEEK_API_KEY.");
+  }
+
+  return new OpenAI({
+    apiKey,
+    baseURL: process.env.DEEPSEEK_BASE_URL ?? "https://api.deepseek.com",
+  });
+}
+
+function getMessageTextContent(
+  content: string | Array<{ text?: string; type?: string }> | null | undefined,
+) {
+  if (typeof content === "string") {
+    return content.trim();
+  }
+
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  return content
+    .filter((item) => item?.type === "text" && typeof item.text === "string")
+    .map((item) => item.text?.trim() ?? "")
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+function getReasoningContent(message: unknown) {
+  if (!message || typeof message !== "object") {
+    return null;
+  }
+
+  const reasoningContent = (message as { reasoning_content?: unknown }).reasoning_content;
+  return typeof reasoningContent === "string" ? reasoningContent : null;
+}
+
+function buildModelTools(allowedToolNames?: string[]) {
+  const allowedSet = allowedToolNames ? new Set(allowedToolNames) : null;
+
+  return listTools()
+    .filter((tool) => (allowedSet ? allowedSet.has(tool.name) : true))
+    .map((tool) => ({
+      type: "function" as const,
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.inputSchema,
+      },
+    }));
+}
+
+function parseToolCallArguments(rawArguments: string) {
+  try {
+    const parsed = JSON.parse(rawArguments) as unknown;
+
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+
+    return parsed as ToolCallArgs;
+  } catch {
+    return null;
+  }
+}
+
+function createSyntheticToolCallId() {
+  return `tool-call-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export async function callModelForText(
+  model: string,
+  messages: LlmMessage[],
+): Promise<ModelTextMessage> {
+  const response = await createModelClient().chat.completions.create({
+    model,
+    messages,
+    extra_body: {
+      thinking: {
+        type: "disabled",
+      },
+    },
+  } as never);
+
+  const message = response.choices[0]?.message;
+  const content = getMessageTextContent(message?.content);
+  const reasoningContent = getReasoningContent(message);
+
+  return {
+    content: content || "I reached the model, but it did not return usable text.",
+    reasoning_content: reasoningContent,
+  };
+}
+
+export async function callModelForToolDecision(
+  model: string,
+  messages: LlmMessage[],
+  allowedToolNames?: string[],
+): Promise<ModelToolMessage> {
+  const response = await createModelClient().chat.completions.create({
+    model,
+    messages,
+    tools: buildModelTools(allowedToolNames),
+    tool_choice: "auto",
+    extra_body: {
+      thinking: {
+        type: "disabled",
+      },
+    },
+  } as never);
+
+  const message = response.choices[0]?.message;
+  const firstToolCall = message?.tool_calls?.[0];
+  const content = getMessageTextContent(message?.content) || null;
+  const reasoningContent = getReasoningContent(message);
+  const assistantMessage: LlmMessage = {
+    role: "assistant",
+    content: message?.content ?? null,
+    reasoning_content: reasoningContent,
+    tool_calls:
+      firstToolCall?.type === "function"
+        ? [
+            {
+              id: firstToolCall.id || createSyntheticToolCallId(),
+              type: "function",
+              function: {
+                name: firstToolCall.function.name,
+                arguments: firstToolCall.function.arguments,
+              },
+            },
+          ]
+        : undefined,
+  };
+
+  if (firstToolCall?.type !== "function") {
+    return {
+      assistantMessage,
+      content,
+      toolCall: null,
+    };
+  }
+
+  const parsedArguments = parseToolCallArguments(firstToolCall.function.arguments);
+  if (!parsedArguments) {
+    return {
+      assistantMessage,
+      content,
+      toolCall: null,
+    };
+  }
+
+  return {
+    assistantMessage,
+    content,
+    toolCall: {
+      id: assistantMessage.tool_calls?.[0]?.id || createSyntheticToolCallId(),
+      name: firstToolCall.function.name,
+      input: parsedArguments,
+    },
+  };
+}

--- a/src/lib/agent/page-result-format.ts
+++ b/src/lib/agent/page-result-format.ts
@@ -1,0 +1,98 @@
+function taskLooksChinese(text: string) {
+  return /[\u4e00-\u9fff]/u.test(text);
+}
+
+function parseReadPageToolContent(content: string) {
+  const lines = content.split(/\r?\n/);
+  const finalUrlLine = lines.find((line) => line.startsWith("final_url: "));
+  const pageTitleLine = lines.find((line) => line.startsWith("page_title: "));
+  const visibleTextIndex = lines.findIndex(
+    (line) => line === "visible_text_sample:",
+  );
+
+  if (!finalUrlLine || !pageTitleLine || visibleTextIndex === -1) {
+    return null;
+  }
+
+  return {
+    finalUrl: finalUrlLine.slice("final_url: ".length).trim(),
+    pageTitle: pageTitleLine.slice("page_title: ".length).trim(),
+    visibleTextSample: lines.slice(visibleTextIndex + 1).join("\n").trim(),
+  };
+}
+
+function parseClickPageToolContent(content: string) {
+  const lines = content.split(/\r?\n/);
+  const clickedSelectorLine = lines.find((line) =>
+    line.startsWith("clicked_selector: "),
+  );
+  const finalUrlLine = lines.find((line) => line.startsWith("final_url: "));
+  const pageTitleLine = lines.find((line) => line.startsWith("page_title: "));
+  const visibleTextIndex = lines.findIndex(
+    (line) => line === "visible_text_sample:",
+  );
+
+  if (
+    !clickedSelectorLine ||
+    !finalUrlLine ||
+    !pageTitleLine ||
+    visibleTextIndex === -1
+  ) {
+    return null;
+  }
+
+  return {
+    clickedSelector: clickedSelectorLine
+      .slice("clicked_selector: ".length)
+      .trim(),
+    finalUrl: finalUrlLine.slice("final_url: ".length).trim(),
+    pageTitle: pageTitleLine.slice("page_title: ".length).trim(),
+    visibleTextSample: lines.slice(visibleTextIndex + 1).join("\n").trim(),
+  };
+}
+
+export function formatReadPageAnswer(goal: string, content: string) {
+  const parsed = parseReadPageToolContent(content);
+
+  if (!parsed) {
+    return null;
+  }
+
+  if (taskLooksChinese(goal)) {
+    return [
+      `最终网址：${parsed.finalUrl}`,
+      `页面标题：${parsed.pageTitle}`,
+      `正文摘录：${parsed.visibleTextSample}`,
+    ].join("\n");
+  }
+
+  return [
+    `Final URL: ${parsed.finalUrl}`,
+    `Page title: ${parsed.pageTitle}`,
+    `Visible text sample: ${parsed.visibleTextSample}`,
+  ].join("\n");
+}
+
+export function formatClickPageAnswer(goal: string, content: string) {
+  const parsed = parseClickPageToolContent(content);
+
+  if (!parsed) {
+    return null;
+  }
+
+  if (taskLooksChinese(goal)) {
+    return [
+      `点击目标：${parsed.clickedSelector}`,
+      `最终网址：${parsed.finalUrl}`,
+      `页面标题：${parsed.pageTitle}`,
+      `正文摘录：${parsed.visibleTextSample}`,
+    ].join("\n");
+  }
+
+  return [
+    `Clicked selector: ${parsed.clickedSelector}`,
+    `Final URL: ${parsed.finalUrl}`,
+    `Page title: ${parsed.pageTitle}`,
+    `Visible text sample: ${parsed.visibleTextSample}`,
+  ].join("\n");
+}

--- a/src/lib/agent/run-agent.ts
+++ b/src/lib/agent/run-agent.ts
@@ -1,27 +1,83 @@
-import { existsSync } from "node:fs";
-import path from "node:path";
-import OpenAI from "openai";
 import type {
   AgentResponse,
   AgentSessionContext,
   AgentStep,
-  AgentStreamEvent,
   ChatMessage,
 } from "@/types/agent";
-import { getTool, listTools } from "@/lib/tools/tool-registry";
+import { listTools } from "@/lib/tools/tool-registry";
 import type {
   ToolCallArgs,
   ToolExecutionInput,
-  ToolResult,
 } from "@/lib/tools/types";
 import {
-  applyPendingWriteDraft,
-  clearPendingWriteDraft,
   getPendingWriteDraft,
   savePendingWriteDraft,
 } from "@/lib/tools/pending-write";
 import { createLogger } from "@/lib/logger";
-import { getWorkspaceRoot } from "@/lib/tools/workspace-path";
+import {
+  formatConversationForModel,
+  formatConversationSummaryForModel,
+  normalizeSessionContext,
+  prepareConversationContext,
+} from "@/lib/agent/conversation-context";
+import {
+  callModelForText,
+  callModelForToolDecision,
+  type LlmMessage,
+} from "@/lib/agent/model-client";
+import {
+  createMessage,
+  createStep,
+  emitStepsSnapshot,
+  finishAgentRun,
+  type RunAgentOptions,
+} from "@/lib/agent/agent-response";
+import {
+  getNumberArg,
+  getStringArg,
+  getStringArrayArg,
+  formatToolExecutionInput,
+  formatToolRunsForModel,
+} from "@/lib/agent/tool-args";
+import {
+  APPROVE_WRITE_COMMAND,
+  CANCEL_WRITE_COMMAND,
+  MAX_TOOL_CALLS,
+  createSyntheticToolCallId,
+  type ToolRun,
+} from "@/lib/agent/tool-run-types";
+import {
+  buildNextSessionContext,
+  formatSessionContextForModel,
+} from "@/lib/agent/session-state";
+import {
+  handleWriteApproval,
+  isAmbiguousDraftConfirmation,
+  parseDraftLifecycleAction,
+  parseWriteCommand,
+} from "@/lib/agent/draft-lifecycle";
+import { runToolCall } from "@/lib/agent/tool-runner";
+import {
+  deriveIssueInvestigationToolCallFromToolRun,
+  deriveIssuePlanToolCallFromToolRun,
+  extractIssuePlanFromGitInspectReport,
+  formatIssueInvestigationAnswer,
+  getLatestIssuePlanText,
+  isIssueDrivenReadForDraft,
+  parseGitInspectAction,
+} from "@/lib/agent/issue-flow";
+import {
+  formatClickPageAnswer,
+  formatReadPageAnswer,
+} from "@/lib/agent/page-result-format";
+import {
+  deriveDirectClickToolCall,
+  deriveDirectGitInspectToolCall,
+  deriveDirectSafeCommandToolCall,
+  deriveFocusedWebSearchQuery,
+  derivePastedIssuePlanToolCall,
+  deriveWebSearchQueryFromTask,
+} from "@/lib/agent/direct-tool-plans";
 
 type AgentContext = {
   cleanTask: string;
@@ -44,217 +100,9 @@ type ThoughtResult = {
   plan: string[];
   step: AgentStep;
   toolCallId: string | null;
-  toolInput: ToolCallArgs | null;
+  toolInput: ToolExecutionInput | null;
   toolName: string | null;
 };
-
-type PlannedToolCall = {
-  id: string;
-  input: ToolCallArgs;
-  name: string;
-};
-
-type DirectToolPlan = {
-  id: string;
-  input: ToolCallArgs;
-  name: string;
-};
-
-type ToolRun = {
-  assistantMessage: LlmMessage;
-  input: ToolExecutionInput;
-  inputText: string;
-  name: string;
-  result: ToolResult;
-  toolCallId: string;
-};
-
-type ModelTextMessage = {
-  content: string;
-  reasoning_content?: string | null;
-};
-
-type ModelToolMessage = {
-  assistantMessage: LlmMessage;
-  content: string | null;
-  toolCall: PlannedToolCall | null;
-};
-
-type LlmMessage = {
-  role: "system" | "user" | "assistant" | "tool";
-  content?: string | Array<{ text?: string; type?: string }> | null;
-  reasoning_content?: string | null;
-  tool_call_id?: string;
-  tool_calls?: Array<{
-    id: string;
-    type: "function";
-    function: {
-      name: string;
-      arguments: string;
-    };
-  }>;
-};
-
-const client = new OpenAI({
-  apiKey: process.env.DEEPSEEK_API_KEY,
-  baseURL: process.env.DEEPSEEK_BASE_URL ?? "https://api.deepseek.com",
-});
-
-const APPROVE_WRITE_COMMAND = "APPROVE_WRITE";
-const CANCEL_WRITE_COMMAND = "CANCEL_WRITE";
-const MAX_CONTEXT_MESSAGES = 8;
-const MAX_TOOL_CALLS = 4;
-
-type WriteCommand =
-  | {
-      type: "approve" | "cancel";
-      draftId: string | null;
-    }
-  | null;
-
-export type RunAgentOptions = {
-  onEvent?: (event: AgentStreamEvent) => void | Promise<void>;
-};
-
-function createStep(id: string, title: string, detail: string): AgentStep {
-  return {
-    id,
-    title,
-    detail,
-    status: "done",
-  };
-}
-
-function createMessage(content: string, reasoningContent?: string | null): ChatMessage {
-  return {
-    id: `assistant-${Date.now()}`,
-    role: "assistant",
-    content,
-    ...(reasoningContent ? { reasoning_content: reasoningContent } : {}),
-  };
-}
-
-function cloneSteps(steps: AgentStep[]) {
-  return steps.map((step) => ({ ...step }));
-}
-
-async function emitAgentEvent(
-  onEvent: RunAgentOptions["onEvent"],
-  event: AgentStreamEvent,
-) {
-  if (!onEvent) {
-    return;
-  }
-
-  await onEvent(event);
-}
-
-async function emitStepsSnapshot(
-  steps: AgentStep[],
-  onEvent: RunAgentOptions["onEvent"],
-) {
-  await emitAgentEvent(onEvent, {
-    type: "steps",
-    steps: cloneSteps(steps),
-  });
-}
-
-async function finishAgentRun(
-  response: AgentResponse,
-  onEvent: RunAgentOptions["onEvent"],
-  includeSteps: boolean,
-) {
-  if (includeSteps) {
-    await emitStepsSnapshot(response.steps, onEvent);
-  }
-
-  await emitAgentEvent(onEvent, {
-    type: "message",
-    message: response.message,
-  });
-  await emitAgentEvent(onEvent, {
-    type: "done",
-    sessionContext: response.sessionContext,
-  });
-
-  return response;
-}
-
-function getMessageTextContent(
-  content: string | Array<{ text?: string; type?: string }> | null | undefined,
-) {
-  if (typeof content === "string") {
-    return content.trim();
-  }
-
-  if (!Array.isArray(content)) {
-    return "";
-  }
-
-  return content
-    .filter((item) => item?.type === "text" && typeof item.text === "string")
-    .map((item) => item.text?.trim() ?? "")
-    .filter(Boolean)
-    .join("\n")
-    .trim();
-}
-
-async function callModelForText(
-  model: string,
-  messages: LlmMessage[],
-) : Promise<ModelTextMessage> {
-  const response = await client.chat.completions.create({
-    model,
-    messages,
-    extra_body: {
-      thinking: {
-        type: "disabled",
-      },
-    },
-  } as never);
-
-  const message = response.choices[0]?.message;
-  const content = getMessageTextContent(message?.content);
-  const reasoningContent = getReasoningContent(message);
-
-  return {
-    content: content || "I reached the model, but it did not return usable text.",
-    reasoning_content: reasoningContent,
-  };
-}
-
-function buildModelTools(allowedToolNames?: string[]) {
-  const allowedSet = allowedToolNames ? new Set(allowedToolNames) : null;
-
-  return listTools()
-    .filter((tool) => (allowedSet ? allowedSet.has(tool.name) : true))
-    .map((tool) => ({
-      type: "function" as const,
-      function: {
-        name: tool.name,
-        description: tool.description,
-        parameters: tool.inputSchema,
-      },
-    }));
-}
-
-function parseToolCallArguments(rawArguments: string) {
-  try {
-    const parsed = JSON.parse(rawArguments) as unknown;
-
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return null;
-    }
-
-    return parsed as ToolCallArgs;
-  } catch {
-    return null;
-  }
-}
-
-function createSyntheticToolCallId() {
-  return `tool-call-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-}
 
 function getRemainingToolCalls(toolRuns: ToolRun[]) {
   return Math.max(MAX_TOOL_CALLS - toolRuns.length, 0);
@@ -384,1025 +232,6 @@ function getImmediateToolOutcome(goal: string, toolRuns: ToolRun[]) {
   return null;
 }
 
-function getReasoningContent(message: unknown) {
-  if (!message || typeof message !== "object") {
-    return null;
-  }
-
-  const reasoningContent = (message as { reasoning_content?: unknown }).reasoning_content;
-  return typeof reasoningContent === "string" ? reasoningContent : null;
-}
-
-async function callModelForToolDecision(
-  model: string,
-  messages: LlmMessage[],
-  allowedToolNames?: string[],
-): Promise<ModelToolMessage> {
-  const response = await client.chat.completions.create({
-    model,
-    messages,
-    tools: buildModelTools(allowedToolNames),
-    tool_choice: "auto",
-    extra_body: {
-      thinking: {
-        type: "disabled",
-      },
-    },
-  } as never);
-
-  const message = response.choices[0]?.message;
-  const firstToolCall = message?.tool_calls?.[0];
-  const content = getMessageTextContent(message?.content) || null;
-  const reasoningContent = getReasoningContent(message);
-  const assistantMessage: LlmMessage = {
-    role: "assistant",
-    content: message?.content ?? null,
-    reasoning_content: reasoningContent,
-    tool_calls:
-      firstToolCall?.type === "function"
-        ? [
-            {
-              id: firstToolCall.id || createSyntheticToolCallId(),
-              type: "function",
-              function: {
-                name: firstToolCall.function.name,
-                arguments: firstToolCall.function.arguments,
-              },
-            },
-          ]
-        : undefined,
-  };
-
-  if (firstToolCall?.type !== "function") {
-    return {
-      assistantMessage,
-      content,
-      toolCall: null,
-    };
-  }
-
-  const parsedArguments = parseToolCallArguments(firstToolCall.function.arguments);
-  if (!parsedArguments) {
-    return {
-      assistantMessage,
-      content,
-      toolCall: null,
-    };
-  }
-
-  return {
-    assistantMessage,
-    content,
-    toolCall: {
-      id: assistantMessage.tool_calls?.[0]?.id || createSyntheticToolCallId(),
-      name: firstToolCall.function.name,
-      input: parsedArguments,
-    },
-  };
-}
-
-function normalizeConversationHistory(messages: ChatMessage[] | undefined, task: string) {
-  if (!messages?.length) {
-    return [];
-  }
-
-  const normalizedMessages = messages
-    .filter((message) => {
-      if (message.role !== "user" && message.role !== "assistant") {
-        return false;
-      }
-
-      return message.content.trim().length > 0;
-    })
-    .map((message) => ({
-      ...message,
-      content: message.content.trim(),
-    }));
-
-  if (normalizedMessages.length === 0) {
-    return [];
-  }
-
-  const lastMessage = normalizedMessages.at(-1);
-  const recentMessages =
-    lastMessage?.role === "user" && lastMessage.content === task.trim()
-      ? normalizedMessages.slice(0, -1)
-      : normalizedMessages;
-
-  return recentMessages.slice(-MAX_CONTEXT_MESSAGES);
-}
-
-function normalizeSessionContext(
-  sessionContext: AgentSessionContext | undefined,
-): AgentSessionContext {
-  if (!sessionContext) {
-    return {};
-  }
-
-  return {
-    lastListedDirectoryPath: sessionContext.lastListedDirectoryPath?.trim() || null,
-    lastReadFilePath: sessionContext.lastReadFilePath?.trim() || null,
-    lastToolInput: sessionContext.lastToolInput?.trim() || null,
-    lastToolName: sessionContext.lastToolName?.trim() || null,
-    pendingDraft: sessionContext.pendingDraft
-      ? {
-          ...sessionContext.pendingDraft,
-          content: sessionContext.pendingDraft.content,
-          id: sessionContext.pendingDraft.id.trim(),
-          path: sessionContext.pendingDraft.path.trim(),
-        }
-      : null,
-  };
-}
-
-function formatConversationForModel(messages: ChatMessage[]) {
-  if (messages.length === 0) {
-    return "No recent conversation.";
-  }
-
-  return messages
-    .map((message) => `${message.role.toUpperCase()}: ${message.content}`)
-    .join("\n\n");
-}
-
-function formatSessionContextForModel(sessionContext: AgentSessionContext) {
-  const lines = [
-    `Last tool name: ${sessionContext.lastToolName ?? "none"}`,
-    `Last tool input: ${sessionContext.lastToolInput ?? "none"}`,
-    `Last listed directory: ${sessionContext.lastListedDirectoryPath ?? "none"}`,
-    `Last read file: ${sessionContext.lastReadFilePath ?? "none"}`,
-  ];
-
-  if (sessionContext.pendingDraft) {
-    lines.push(`Pending draft id: ${sessionContext.pendingDraft.id}`);
-    lines.push(`Pending draft path: ${sessionContext.pendingDraft.path}`);
-    lines.push("Pending draft content:");
-    lines.push(sessionContext.pendingDraft.content || "(empty file)");
-  } else {
-    lines.push("Pending draft id: none");
-  }
-
-  lines.push(
-    "Reference rules: if the user says 'that draft' or '那个 draft', prefer the pending draft. If the user says 'that file' or '那个文件', prefer the pending draft path first, then the last read file. If the user says 'continue the last step' or '继续上一步', prefer continuing the pending draft flow, otherwise use the last tool context.",
-  );
-
-  return lines.join("\n");
-}
-
-function buildNextSessionContext(
-  previousContext: AgentSessionContext,
-  toolRuns: ToolRun[],
-): AgentSessionContext {
-  const nextContext: AgentSessionContext = {
-    ...previousContext,
-  };
-
-  for (const toolRun of toolRuns) {
-    nextContext.lastToolName = toolRun.name;
-    nextContext.lastToolInput = toolRun.inputText;
-
-    if (toolRun.name === "list_files") {
-      nextContext.lastListedDirectoryPath = getToolPathReference(toolRun.input);
-    }
-
-    if (toolRun.name === "read_file") {
-      nextContext.lastReadFilePath = getToolPathReference(toolRun.input);
-    }
-
-    if (toolRun.result.draft) {
-      nextContext.pendingDraft = toolRun.result.draft;
-    }
-  }
-
-  return nextContext;
-}
-
-function parseTagBlock(text: string, tagName: string) {
-  const pattern = new RegExp(`<${tagName}>([\\s\\S]*?)</${tagName}>`);
-  const match = text.match(pattern);
-  return match?.[1]?.trim() ?? null;
-}
-
-function getStringArg(args: ToolCallArgs, key: string) {
-  const value = args[key];
-  return typeof value === "string" ? value.trim() : "";
-}
-
-function getStringArrayArg(args: ToolCallArgs, key: string) {
-  const value = args[key];
-
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.filter((item): item is string => typeof item === "string");
-}
-
-function getNumberArg(args: ToolCallArgs, key: string) {
-  const value = args[key];
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
-}
-
-function getToolPathReference(input: ToolExecutionInput) {
-  if (typeof input === "string") {
-    return input.trim() || null;
-  }
-
-  return getStringArg(input, "path") || null;
-}
-
-function formatToolExecutionInput(input: ToolExecutionInput) {
-  if (typeof input === "string") {
-    return input;
-  }
-
-  return JSON.stringify(input);
-}
-
-function formatToolRunsForModel(toolRuns: ToolRun[]) {
-  return toolRuns
-    .map((toolRun, index) =>
-      [
-        `Tool result ${index + 1}:`,
-        `name: ${toolRun.name}`,
-        `input: ${toolRun.inputText}`,
-        `ok: ${toolRun.result.ok ? "true" : "false"}`,
-        "content:",
-        toolRun.result.content,
-      ].join("\n"),
-    )
-    .join("\n\n");
-}
-
-function parseReadPageToolContent(content: string) {
-  const lines = content.split(/\r?\n/);
-  const finalUrlLine = lines.find((line) => line.startsWith("final_url: "));
-  const pageTitleLine = lines.find((line) => line.startsWith("page_title: "));
-  const visibleTextIndex = lines.findIndex((line) => line === "visible_text_sample:");
-
-  if (!finalUrlLine || !pageTitleLine || visibleTextIndex === -1) {
-    return null;
-  }
-
-  return {
-    finalUrl: finalUrlLine.slice("final_url: ".length).trim(),
-    pageTitle: pageTitleLine.slice("page_title: ".length).trim(),
-    visibleTextSample: lines.slice(visibleTextIndex + 1).join("\n").trim(),
-  };
-}
-
-function parseClickPageToolContent(content: string) {
-  const lines = content.split(/\r?\n/);
-  const clickedSelectorLine = lines.find((line) =>
-    line.startsWith("clicked_selector: "),
-  );
-  const finalUrlLine = lines.find((line) => line.startsWith("final_url: "));
-  const pageTitleLine = lines.find((line) => line.startsWith("page_title: "));
-  const visibleTextIndex = lines.findIndex((line) => line === "visible_text_sample:");
-
-  if (
-    !clickedSelectorLine ||
-    !finalUrlLine ||
-    !pageTitleLine ||
-    visibleTextIndex === -1
-  ) {
-    return null;
-  }
-
-  return {
-    clickedSelector: clickedSelectorLine
-      .slice("clicked_selector: ".length)
-      .trim(),
-    finalUrl: finalUrlLine.slice("final_url: ".length).trim(),
-    pageTitle: pageTitleLine.slice("page_title: ".length).trim(),
-    visibleTextSample: lines.slice(visibleTextIndex + 1).join("\n").trim(),
-  };
-}
-
-function parseReportSection(
-  content: string,
-  sectionName: string,
-  nextSectionNames: string[],
-) {
-  const lines = content.split(/\r?\n/);
-  const startIndex = lines.findIndex(
-    (line) => line.trim() === `${sectionName}:`,
-  );
-
-  if (startIndex === -1) {
-    return null;
-  }
-
-  const collectedLines: string[] = [];
-
-  for (let index = startIndex + 1; index < lines.length; index += 1) {
-    const trimmedLine = lines[index]?.trim();
-
-    if (nextSectionNames.some((name) => trimmedLine === `${name}:`)) {
-      break;
-    }
-
-    collectedLines.push(lines[index] ?? "");
-  }
-
-  const sectionContent = collectedLines.join("\n").trim();
-  return sectionContent && sectionContent !== "(none)" ? sectionContent : null;
-}
-
-function parseGitInspectAction(content: string) {
-  const match = content.match(/^action:\s*(.+)$/m);
-  return match?.[1]?.trim() ?? null;
-}
-
-function extractIssueDetailFromGitInspectReport(content: string) {
-  return parseReportSection(content, "issue_detail", ["issue_list"]);
-}
-
-function extractIssuePlanFromGitInspectReport(content: string) {
-  return parseReportSection(content, "issue_plan", ["repo_info"]);
-}
-
-function isStructuredIssueDetail(text: string) {
-  return /^#\d+\s+\[[A-Z]+\]\s+/m.test(text);
-}
-
-function deriveIssuePlanToolCallFromToolRun(
-  toolRun: ToolRun,
-): PlannedToolCall | null {
-  if (toolRun.name !== "git_inspect" || !toolRun.result.ok) {
-    return null;
-  }
-
-  if (parseGitInspectAction(toolRun.result.content) !== "issue_detail") {
-    return null;
-  }
-
-  const issueDetail = extractIssueDetailFromGitInspectReport(toolRun.result.content);
-
-  if (!issueDetail || !isStructuredIssueDetail(issueDetail)) {
-    return null;
-  }
-
-  return {
-    id: createSyntheticToolCallId(),
-    name: "git_inspect",
-    input: {
-      action: "issue_plan",
-      issue_text: issueDetail,
-    },
-  };
-}
-
-function extractBulletItems(sectionContent: string | null) {
-  if (!sectionContent) {
-    return [];
-  }
-
-  return sectionContent
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line.startsWith("- "))
-    .map((line) => line.slice(2).trim())
-    .filter(Boolean);
-}
-
-function looksLikeWorkspacePath(value: string) {
-  return /(?:[A-Za-z0-9_.-]+[\\/])+[A-Za-z0-9_.-]+|[A-Za-z0-9_.-]+\.(?:ts|tsx|js|jsx|json|md|css|scss|html)$/i.test(
-    value,
-  );
-}
-
-function getDefaultIssueSearchPath() {
-  const workspaceRoot = getWorkspaceRoot();
-  const candidatePath =
-    ["src", "app", "pages", "components", "lib"].find((candidate) =>
-      existsSync(path.join(workspaceRoot, candidate)),
-    ) ?? ".";
-
-  return candidatePath;
-}
-
-function extractIssuePlanCandidatePaths(issuePlan: string) {
-  return extractBulletItems(
-    parseReportSection(issuePlan, "Possible related files or modules", [
-      "Useful search keywords",
-    ]),
-  ).filter((item) => looksLikeWorkspacePath(item));
-}
-
-function extractIssuePlanKeywords(issuePlan: string) {
-  const keywordLines = extractBulletItems(
-    parseReportSection(issuePlan, "Useful search keywords", [
-      "Recommended first step",
-    ]),
-  );
-
-  if (keywordLines.length === 0) {
-    return [];
-  }
-
-  return keywordLines
-    .flatMap((line) => line.split(","))
-    .map((item) => item.trim())
-    .filter((item) => item.length > 0 && item !== "(need manual triage)");
-}
-
-function deriveIssueInvestigationToolCallFromToolRun(
-  toolRun: ToolRun,
-): PlannedToolCall | null {
-  if (toolRun.name !== "git_inspect" || !toolRun.result.ok) {
-    return null;
-  }
-
-  if (parseGitInspectAction(toolRun.result.content) !== "issue_plan") {
-    return null;
-  }
-
-  const issuePlan = extractIssuePlanFromGitInspectReport(toolRun.result.content);
-
-  if (!issuePlan) {
-    return null;
-  }
-
-  const candidatePaths = extractIssuePlanCandidatePaths(issuePlan);
-  if (candidatePaths.length > 0) {
-    return {
-      id: createSyntheticToolCallId(),
-      name: "read_file",
-      input: {
-        path: candidatePaths[0],
-      },
-    };
-  }
-
-  const keywords = extractIssuePlanKeywords(issuePlan);
-  if (keywords.length > 0) {
-    return {
-      id: createSyntheticToolCallId(),
-      name: "search_text",
-      input: {
-        query: keywords[0],
-        path: getDefaultIssueSearchPath(),
-      },
-    };
-  }
-
-  return null;
-}
-
-function findLatestIssuePlanIndex(toolRuns: ToolRun[]) {
-  for (let index = toolRuns.length - 1; index >= 0; index -= 1) {
-    const toolRun = toolRuns[index];
-    if (
-      toolRun.name === "git_inspect" &&
-      toolRun.result.ok &&
-      parseGitInspectAction(toolRun.result.content) === "issue_plan" &&
-      extractIssuePlanFromGitInspectReport(toolRun.result.content)
-    ) {
-      return index;
-    }
-  }
-
-  return -1;
-}
-
-function getLatestIssuePlanText(toolRuns: ToolRun[]) {
-  const latestIssuePlanIndex = findLatestIssuePlanIndex(toolRuns);
-
-  if (latestIssuePlanIndex === -1) {
-    return null;
-  }
-
-  return extractIssuePlanFromGitInspectReport(
-    toolRuns[latestIssuePlanIndex]?.result.content ?? "",
-  );
-}
-
-function isIssueDrivenReadForDraft(toolRuns: ToolRun[]) {
-  const latestToolRun = toolRuns.at(-1);
-
-  if (
-    !latestToolRun ||
-    latestToolRun.name !== "read_file" ||
-    !latestToolRun.result.ok
-  ) {
-    return false;
-  }
-
-  const latestIssuePlanIndex = findLatestIssuePlanIndex(toolRuns);
-  return latestIssuePlanIndex !== -1 && latestIssuePlanIndex < toolRuns.length - 1;
-}
-
-function extractIssueGoalFromPlan(issuePlan: string) {
-  const goalLines = extractBulletItems(
-    parseReportSection(issuePlan, "What this issue is trying to fix", [
-      "Possible related files or modules",
-    ]),
-  );
-
-  return goalLines[0] ?? "Need manual issue summary.";
-}
-
-function buildPreviewText(content: string, maxLines: number, maxChars: number) {
-  const preview = content
-    .split(/\r?\n/)
-    .map((line) => line.trimEnd())
-    .filter((line) => line.trim().length > 0)
-    .slice(0, maxLines)
-    .join("\n")
-    .trim();
-
-  if (!preview) {
-    return "(empty)";
-  }
-
-  if (preview.length <= maxChars) {
-    return preview;
-  }
-
-  return `${preview.slice(0, maxChars)}\n[preview truncated]`;
-}
-
-function parseSearchResultMatches(content: string) {
-  return content
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => /^[^:\s][^:]*:\d+:\s/.test(line))
-    .map((line) => {
-      const match = line.match(/^(.*?):(\d+):\s*(.*)$/);
-      return match
-        ? {
-            path: match[1].trim(),
-            line: match[2].trim(),
-            snippet: match[3].trim(),
-          }
-        : null;
-    })
-    .filter(
-      (
-        item,
-      ): item is {
-        line: string;
-        path: string;
-        snippet: string;
-      } => item !== null,
-    );
-}
-
-function formatIssueInvestigationAnswer(goal: string, toolRuns: ToolRun[]) {
-  const latestToolRun = toolRuns.at(-1);
-
-  if (!latestToolRun || !latestToolRun.result.ok) {
-    return null;
-  }
-
-  if (latestToolRun.name !== "read_file" && latestToolRun.name !== "search_text") {
-    return null;
-  }
-
-  const latestIssuePlanIndex = findLatestIssuePlanIndex(toolRuns);
-  if (latestIssuePlanIndex === -1 || latestIssuePlanIndex >= toolRuns.length - 1) {
-    return null;
-  }
-
-  const issuePlan = extractIssuePlanFromGitInspectReport(
-    toolRuns[latestIssuePlanIndex]?.result.content ?? "",
-  );
-
-  if (!issuePlan) {
-    return null;
-  }
-
-  const issueGoal = extractIssueGoalFromPlan(issuePlan);
-  const isChinese = taskLooksChinese(goal);
-
-  if (latestToolRun.name === "read_file") {
-    const targetPath = getToolPathReference(latestToolRun.input) ?? "(unknown file)";
-    const preview = buildPreviewText(latestToolRun.result.content, 12, 900);
-
-    return isChinese
-      ? [
-          "第一步调查结果：",
-          `- 这个 issue 想解决：${issueGoal}`,
-          `- 当前优先怀疑位置：${targetPath}`,
-          "- 为什么先看这里：这份施工单已经把它列成了候选文件，所以先确认这里是不是问题发生点。",
-          "- 代码预览：",
-          preview,
-          "建议下一步：",
-          `- 继续围绕 ${targetPath} 里和 issue 相关的函数、条件分支或渲染位置缩小范围。`,
-          "- 确认这是不是最小改动点后，再决定用 replace_text 还是 write_file 准备改动草稿。",
-          "验证提醒：",
-          "- 保留 issue 里的复现方式，改完后走同一遍检查。",
-          "- 最后跑一次 npm run build。",
-        ].join("\n")
-      : [
-          "First investigation result:",
-          `- Issue goal: ${issueGoal}`,
-          `- Current likely edit target: ${targetPath}`,
-          "- Why this file first: the execution plan named it as a likely file, so this is the safest first inspection point.",
-          "- Code preview:",
-          preview,
-          "Recommended next step:",
-          `- Narrow the scope inside ${targetPath} to the specific function, branch, or render path tied to the issue.`,
-          "- Once the smallest edit point is clear, choose replace_text or write_file for the draft.",
-          "Validation reminder:",
-          "- Re-run the same issue scenario after the change.",
-          "- Run npm run build at the end.",
-        ].join("\n");
-  }
-
-  const matches = parseSearchResultMatches(latestToolRun.result.content);
-  const topMatches = matches.slice(0, 3);
-  const firstMatch = topMatches[0];
-  const searchedKeyword =
-    typeof latestToolRun.input === "string"
-      ? latestToolRun.input
-      : getStringArg(latestToolRun.input, "query") || "(unknown keyword)";
-  const preview =
-    topMatches.length > 0
-      ? topMatches
-          .map(
-            (match) => `- ${match.path}:${match.line}: ${match.snippet}`,
-          )
-          .join("\n")
-      : latestToolRun.result.content;
-
-  return isChinese
-    ? [
-        "第一步调查结果：",
-        `- 这个 issue 想解决：${issueGoal}`,
-        `- 当前优先搜索词：${searchedKeyword}`,
-        firstMatch
-          ? `- 当前更像改动入口的位置：${firstMatch.path}:${firstMatch.line}`
-          : "- 还没有找到明确的改动入口。",
-        "- 为什么先看这里：施工单没有点名具体文件，所以先用关键词在代码里找落点。",
-        "- 搜索命中预览：",
-        preview,
-        "建议下一步：",
-        firstMatch
-          ? `- 先读 ${firstMatch.path}，确认这段命中是不是和 issue 描述的行为直接相关。`
-          : "- 换一个更具体的关键词，再搜一次。",
-        "- 定位到真正相关的文件后，再决定最小改动点。",
-        "验证提醒：",
-        "- 保留 issue 里的复现方式，改完后走同一遍检查。",
-        "- 最后跑一次 npm run build。",
-      ].join("\n")
-    : [
-        "First investigation result:",
-        `- Issue goal: ${issueGoal}`,
-        `- Current search keyword: ${searchedKeyword}`,
-        firstMatch
-          ? `- Current likely entry point: ${firstMatch.path}:${firstMatch.line}`
-          : "- No clear edit entry point has been found yet.",
-        "- Why start here: the plan did not name one exact file, so the safest first move is keyword search.",
-        "- Search preview:",
-        preview,
-        "Recommended next step:",
-        firstMatch
-          ? `- Read ${firstMatch.path} next and confirm whether that hit is directly tied to the issue behavior.`
-          : "- Try a more specific search keyword and search again.",
-        "- Once the real file is confirmed, narrow to the smallest edit point.",
-        "Validation reminder:",
-        "- Re-run the same issue scenario after the change.",
-        "- Run npm run build at the end.",
-      ].join("\n");
-}
-
-function taskLooksChinese(text: string) {
-  return /[\u4e00-\u9fff]/u.test(text);
-}
-
-function extractUrlFromTask(task: string) {
-  const match = task.match(/https?:\/\/[^\s)>"']+|www\.[^\s)>"']+/i);
-  return match?.[0]?.trim() ?? null;
-}
-
-function cleanClickTargetLabel(rawLabel: string) {
-  return rawLabel
-    .trim()
-    .replace(/^["'“”‘’]+|["'“”‘’]+$/gu, "")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function deriveClickSelectorFromTask(task: string) {
-  if (/\bclick\s+the\s+first\s+link\b/i.test(task) || /点击第一个链接/.test(task)) {
-    return "a";
-  }
-
-  if (/\bclick\s+the\s+first\s+button\b/i.test(task) || /点击第一个按钮/.test(task)) {
-    return "button";
-  }
-
-  const englishLinkMatch = task.match(/\bclick\s+(?:the\s+)?(.+?)\s+link\b/i);
-  if (englishLinkMatch?.[1]) {
-    const label = cleanClickTargetLabel(englishLinkMatch[1]);
-    if (label) {
-      return `text=${label}`;
-    }
-  }
-
-  const englishButtonMatch = task.match(/\bclick\s+(?:the\s+)?(.+?)\s+button\b/i);
-  if (englishButtonMatch?.[1]) {
-    const label = cleanClickTargetLabel(englishButtonMatch[1]);
-    if (label) {
-      return `text=${label}`;
-    }
-  }
-
-  const chineseLinkMatch = task.match(/点击(.+?)链接/);
-  if (chineseLinkMatch?.[1]) {
-    const label = cleanClickTargetLabel(chineseLinkMatch[1]);
-    if (label) {
-      return `text=${label}`;
-    }
-  }
-
-  const chineseButtonMatch = task.match(/点击(.+?)按钮/);
-  if (chineseButtonMatch?.[1]) {
-    const label = cleanClickTargetLabel(chineseButtonMatch[1]);
-    if (label) {
-      return `text=${label}`;
-    }
-  }
-
-  return null;
-}
-
-function deriveMaxCharsFromTask(task: string) {
-  const englishMatch = task.match(
-    /\b(?:around|about|roughly|only|just)?\s*(\d{2,4})\s*(?:characters|character|chars)\b/i,
-  );
-  if (englishMatch?.[1]) {
-    return Number(englishMatch[1]);
-  }
-
-  const chineseMatch = task.match(/(\d{2,4})\s*字/);
-  if (chineseMatch?.[1]) {
-    return Number(chineseMatch[1]);
-  }
-
-  return null;
-}
-
-function deriveDirectClickToolCall(task: string): PlannedToolCall | null {
-  const url = extractUrlFromTask(task);
-  const selector = deriveClickSelectorFromTask(task);
-  const maxChars = deriveMaxCharsFromTask(task);
-
-  if (!url || !selector) {
-    return null;
-  }
-
-  return {
-    id: createSyntheticToolCallId(),
-    name: "click_page",
-    input:
-      maxChars === null
-        ? {
-            url,
-            selector,
-          }
-        : {
-            url,
-            selector,
-            max_chars: maxChars,
-          },
-  };
-}
-
-function deriveDirectSafeCommandToolCall(task: string): DirectToolPlan | null {
-  const cleanTask = task.trim();
-
-  const asksForGitStatus =
-    /\bgit\s+status\b/i.test(cleanTask) ||
-    /(仓库状态|git状态|当前状态|工作区状态)/.test(cleanTask);
-
-  if (asksForGitStatus) {
-    return {
-      id: createSyntheticToolCallId(),
-      name: "safe_command",
-      input: {
-        command: "git",
-        args: ["status"],
-      },
-    };
-  }
-
-  const asksForBuild =
-    /\bnpm\s+run\s+build\b/i.test(cleanTask) ||
-    /\bbuild\b/i.test(cleanTask) ||
-    /(构建|编译|跑一下构建|构建检查|验证构建|检查能不能构建)/.test(cleanTask);
-
-  if (asksForBuild) {
-    return {
-      id: createSyntheticToolCallId(),
-      name: "safe_command",
-      input: {
-        command: "npm",
-        args: ["run", "build"],
-      },
-    };
-  }
-
-  const asksForTest =
-    /\bnpm\s+test\b/i.test(cleanTask) ||
-    /\btest\b/i.test(cleanTask) ||
-    /(测试|跑测试|执行测试|验证测试|检查测试)/.test(cleanTask);
-
-  if (asksForTest) {
-    return {
-      id: createSyntheticToolCallId(),
-      name: "safe_command",
-      input: {
-        command: "npm",
-        args: ["test"],
-      },
-    };
-  }
-
-  return null;
-}
-
-function deriveDirectGitInspectToolCall(task: string): DirectToolPlan | null {
-  const cleanTask = task.trim();
-  const asksForIssuePlan =
-    /(issue\s*(计划|execution\s*plan)|执行计划|改代码计划)/i.test(cleanTask);
-  const issueDetailMatch =
-    cleanTask.match(/\bissue\s+#?(\d+)\b/i) ||
-    cleanTask.match(/issue\s*详情\s*#?(\d+)/i) ||
-    cleanTask.match(/第\s*(\d+)\s*个\s*issue/i) ||
-    cleanTask.match(/issue\s*(\d+)/i);
-
-  if (asksForIssuePlan && issueDetailMatch?.[1]) {
-    return {
-      id: createSyntheticToolCallId(),
-      name: "git_inspect",
-      input: {
-        action: "issue_plan",
-        issue_number: Number(issueDetailMatch[1]),
-      },
-    };
-  }
-
-  if (issueDetailMatch?.[1]) {
-    return {
-      id: createSyntheticToolCallId(),
-      name: "git_inspect",
-      input: {
-        action: "issue_detail",
-        issue_number: Number(issueDetailMatch[1]),
-      },
-    };
-  }
-
-  const asksForIssueList =
-    /\bissues?\b/i.test(cleanTask) ||
-    /(issue 列表|issues 列表|当前 issue|仓库 issue|待办单|问题列表)/i.test(
-      cleanTask,
-    );
-
-  if (asksForIssueList) {
-    return {
-      id: createSyntheticToolCallId(),
-      name: "git_inspect",
-      input: {
-        action: "issue_list",
-      },
-    };
-  }
-
-  const asksForRepoInfo =
-    /\brepo\b/i.test(cleanTask) ||
-    /(仓库信息|当前仓库|repo info|repository info|仓库详情|github 仓库信息)/i.test(
-      cleanTask,
-    );
-
-  if (asksForRepoInfo) {
-    return {
-      id: createSyntheticToolCallId(),
-      name: "git_inspect",
-      input: {
-        action: "repo_info",
-      },
-    };
-  }
-
-  const asksForPrDraft =
-    /\bpr\b/i.test(cleanTask) ||
-    /(pr 草稿|pull request|拉取请求|合并请求|pr 文案|pr draft|帮我写 pr)/i.test(
-      cleanTask,
-    );
-
-  if (asksForPrDraft) {
-    return {
-      id: createSyntheticToolCallId(),
-      name: "git_inspect",
-      input: {
-        action: "pr_draft",
-      },
-    };
-  }
-
-  const asksForCommitMessage =
-    /\bcommit\s+message\b/i.test(cleanTask) ||
-    /(提交说明|提交信息|commit 文案|commit message|帮我写提交信息|帮我写 commit)/i.test(
-      cleanTask,
-    );
-
-  if (asksForCommitMessage) {
-    return {
-      id: createSyntheticToolCallId(),
-      name: "git_inspect",
-      input: {
-        action: "commit_message",
-      },
-    };
-  }
-
-  const asksForGithubEnv =
-    /\bgh\b/i.test(cleanTask) ||
-    /(github|remote|origin).{0,12}(连接|连上|环境|状态|检查|配置)/i.test(cleanTask) ||
-    /(有没有\s*remote|有没有\s*github\s*remote|能不能用\s*gh|github\s*登录|gh\s*登录)/i.test(
-      cleanTask,
-    );
-
-  if (asksForGithubEnv) {
-    return {
-      id: createSyntheticToolCallId(),
-      name: "git_inspect",
-      input: {
-        action: "github_env",
-      },
-    };
-  }
-
-  const asksForGitSummary =
-    /(?:git|change|diff|status)\s+summary/i.test(cleanTask) ||
-    /(变更总结|改动总结|总结改动|总结变更|git总结|git 摘要|change summary)/i.test(
-      cleanTask,
-    );
-
-  if (asksForGitSummary) {
-    return {
-      id: createSyntheticToolCallId(),
-      name: "git_inspect",
-      input: {
-        action: "summary",
-      },
-    };
-  }
-
-  const asksForGitDiff =
-    /\bgit\s+diff\b/i.test(cleanTask) ||
-    /(git\s*diff|仓库差异|改动差异|变更差异|查看差异|看看差异)/i.test(cleanTask);
-
-  if (asksForGitDiff) {
-    return {
-      id: createSyntheticToolCallId(),
-      name: "git_inspect",
-      input: {
-        action: "diff",
-      },
-    };
-  }
-
-  const asksForGitStatus =
-    /\bgit\s+status\b/i.test(cleanTask) ||
-    /(git\s*状态|仓库状态|工作区状态|改动状态|查看状态|看看状态)/i.test(cleanTask);
-
-  if (asksForGitStatus) {
-    return {
-      id: createSyntheticToolCallId(),
-      name: "git_inspect",
-      input: {
-        action: "status",
-      },
-    };
-  }
-
-  const asksWhetherGitRepo =
-    /\bgit\s+(repo|repository)\b/i.test(cleanTask) ||
-    /(是不是|是否|算不算|当前目录|这个目录|这个项目).{0,12}(git\s*仓库|git\s*repo|git\s*repository)/i.test(
-      cleanTask,
-    ) ||
-    /(git\s*仓库|git\s*repo|git\s*repository).{0,12}(吗|没有|情况|状态|检查)/i.test(
-      cleanTask,
-    );
-
-  if (!asksWhetherGitRepo) {
-    return null;
-  }
-
-  return {
-    id: createSyntheticToolCallId(),
-    name: "git_inspect",
-    input: {
-      action: "check_repo",
-    },
-  };
-}
-
 function isVerificationSafeCommandInput(input: ToolExecutionInput) {
   if (typeof input === "string") {
     return false;
@@ -1422,52 +251,6 @@ function isVerificationSafeCommandInput(input: ToolExecutionInput) {
   );
 }
 
-function formatReadPageAnswer(goal: string, content: string) {
-  const parsed = parseReadPageToolContent(content);
-
-  if (!parsed) {
-    return null;
-  }
-
-  if (taskLooksChinese(goal)) {
-    return [
-      `最终网址：${parsed.finalUrl}`,
-      `页面标题：${parsed.pageTitle}`,
-      `正文摘录：${parsed.visibleTextSample}`,
-    ].join("\n");
-  }
-
-  return [
-    `Final URL: ${parsed.finalUrl}`,
-    `Page title: ${parsed.pageTitle}`,
-    `Visible text sample: ${parsed.visibleTextSample}`,
-  ].join("\n");
-}
-
-function formatClickPageAnswer(goal: string, content: string) {
-  const parsed = parseClickPageToolContent(content);
-
-  if (!parsed) {
-    return null;
-  }
-
-  if (taskLooksChinese(goal)) {
-    return [
-      `点击目标：${parsed.clickedSelector}`,
-      `最终网址：${parsed.finalUrl}`,
-      `页面标题：${parsed.pageTitle}`,
-      `正文摘录：${parsed.visibleTextSample}`,
-    ].join("\n");
-  }
-
-  return [
-    `Clicked selector: ${parsed.clickedSelector}`,
-    `Final URL: ${parsed.finalUrl}`,
-    `Page title: ${parsed.pageTitle}`,
-    `Visible text sample: ${parsed.visibleTextSample}`,
-  ].join("\n");
-}
-
 function normalizeToolInput(toolName: string, rawInput: ToolCallArgs, task: string) {
   if (toolName === "list_files") {
     return {
@@ -1477,7 +260,19 @@ function normalizeToolInput(toolName: string, rawInput: ToolCallArgs, task: stri
 
   if (toolName === "read_file") {
     const path = getStringArg(rawInput, "path");
-    return path ? { path } : null;
+
+    if (!path) {
+      return null;
+    }
+
+    const startLine = getNumberArg(rawInput, "start_line");
+    const maxLines = getNumberArg(rawInput, "max_lines");
+
+    return {
+      path,
+      ...(startLine === null ? {} : { start_line: startLine }),
+      ...(maxLines === null ? {} : { max_lines: maxLines }),
+    };
   }
 
   if (toolName === "read_page") {
@@ -1567,478 +362,11 @@ function normalizeToolInput(toolName: string, rawInput: ToolCallArgs, task: stri
     const query = getStringArg(rawInput, "query");
 
     return {
-      query: deriveFocusedWebSearchQuery(query || task),
+      query: deriveFocusedWebSearchQuery(deriveWebSearchQueryFromTask(query || task)),
     };
   }
 
   return rawInput;
-}
-
-function derivePastedIssuePlanToolCall(task: string): DirectToolPlan | null {
-  const cleanTask = task.trim();
-  const hasPastedIssueText =
-    /(?:^|\n)\s*title\s*:/i.test(cleanTask) &&
-    /(?:^|\n)\s*body\s*:/i.test(cleanTask);
-  const mentionsIssue = /\bissue\b/i.test(cleanTask);
-
-  if (!hasPastedIssueText || !mentionsIssue) {
-    return null;
-  }
-
-  return {
-    id: createSyntheticToolCallId(),
-    name: "git_inspect",
-    input: {
-      action: "issue_plan",
-      issue_text: cleanTask,
-    },
-  };
-}
-
-function stripLeadingMatch(text: string, patterns: RegExp[]) {
-  let nextText = text.trim();
-
-  for (const pattern of patterns) {
-    const updated = nextText.replace(pattern, "").trim();
-    if (updated !== nextText) {
-      nextText = updated;
-    }
-  }
-
-  return nextText;
-}
-
-function stripTrailingMatch(text: string, patterns: RegExp[]) {
-  let nextText = text.trim();
-
-  for (const pattern of patterns) {
-    const updated = nextText.replace(pattern, "").trim();
-    if (updated !== nextText) {
-      nextText = updated;
-    }
-  }
-
-  return nextText;
-}
-
-function deriveWebSearchQueryFromTask(task: string) {
-  const taggedQuery = parseTagBlock(task, "query");
-  if (taggedQuery) {
-    return taggedQuery;
-  }
-
-  let query = task.trim();
-
-  query = stripLeadingMatch(query, [
-    /^(?:请帮我|帮我|请你|请|麻烦你|麻烦)\s*/u,
-    /^(?:在网上|上网|在线)\s*/u,
-    /^(?:搜索一下|搜索|搜一下|搜一搜|搜搜|查一下|查一查|查查|查找|查询|找一下)\s*/u,
-    /^(?:关于|一下)\s*/u,
-    /^(?:please\s+)?(?:search|look up|find)\s+(?:for\s+)?/iu,
-  ]);
-
-  query = stripTrailingMatch(query, [
-    /[\u3002\uFF0C\uFF01\uFF1F,!.?]?\s*(?:并|然后|再)?\s*(?:把|将)?\s*(?:网页)?标题和链接(?:告诉我|给我|发我)?\s*$/u,
-    /[\u3002\uFF0C\uFF01\uFF1F,!.?]?\s*(?:只要|只需要)?\s*(?:网页)?标题和链接\s*$/u,
-    /[\u3002\uFF0C\uFF01\uFF1F,!.?]?\s*(?:告诉我|给我|发我|列出来)\s*$/u,
-    /\s*(?:and\s+)?(?:give|tell|show)\s+me\s+(?:the\s+)?title(?:s)?\s+and\s+link(?:s)?\s*$/iu,
-  ]);
-
-  query = query.replace(/^["'“”‘’\s]+|["'“”‘’\s]+$/gu, "").trim();
-
-  return query || task.trim();
-}
-
-function hasWhoSearchIntent(text: string) {
-  return /(?:\u662f\u8c01|\u4ec0\u4e48\u4eba|\u8c01\u554a|\u8c01\u5440)/u.test(text);
-}
-
-function hasWhenSearchIntent(text: string) {
-  return /(?:\u4ec0\u4e48\u65f6\u5019|\u5565\u65f6\u5019|\u4f55\u65f6|\u51e0\u70b9|\u51e0\u53f7|\u54ea\u5929|when|what\s+time|what\s+date)/iu.test(
-    text,
-  );
-}
-
-function hasEndSearchIntent(text: string) {
-  return /(?:\u7ed3\u675f|\u622a\u6b62|end|ending|ends)/iu.test(text);
-}
-
-function hasStartSearchIntent(text: string) {
-  return /(?:\u5f00\u59cb|\u5f00\u5e55|start|begin|opening)/iu.test(text);
-}
-
-function collapseSearchTerms(text: string) {
-  return text.replace(/\s+/g, " ").trim();
-}
-
-function appendSearchTerms(query: string, suffix: string) {
-  const normalizedQuery = collapseSearchTerms(query);
-
-  if (!normalizedQuery) {
-    return suffix;
-  }
-
-  if (normalizedQuery.toLowerCase().includes(suffix.toLowerCase())) {
-    return normalizedQuery;
-  }
-
-  return `${normalizedQuery} ${suffix}`;
-}
-
-function deriveFocusedWebSearchQuery(task: string) {
-  const taggedQuery = parseTagBlock(task, "query");
-  if (taggedQuery) {
-    return taggedQuery;
-  }
-
-  const originalTask = task.trim();
-  const asksWho = hasWhoSearchIntent(originalTask);
-  const asksWhen = hasWhenSearchIntent(originalTask);
-  const asksEnd = hasEndSearchIntent(originalTask);
-  const asksStart = hasStartSearchIntent(originalTask);
-
-  let query = originalTask;
-
-  query = stripLeadingMatch(query, [
-    /^(?:\u8bf7\u5e2e\u6211|\u5e2e\u6211|\u8bf7\u4f60|\u8bf7|\u9ebb\u70e6\u4f60|\u9ebb\u70e6)\s*/u,
-    /^(?:\u5728\u7f51\u4e0a|\u4e0a\u7f51|\u5728\u7ebf)\s*/u,
-    /^(?:\u641c\u7d22\u4e00\u4e0b|\u641c\u7d22|\u641c\u4e00\u4e0b|\u641c\u4e00\u641c|\u641c\u641c|\u67e5\u4e00\u4e0b|\u67e5\u4e00\u67e5|\u67e5\u67e5|\u67e5\u627e|\u67e5\u8be2|\u627e\u4e00\u4e0b)\s*/u,
-    /^(?:\u5173\u4e8e|\u4e00\u4e0b)\s*/u,
-    /^(?:please\s+)?(?:search|look up|find)\s+(?:for\s+)?/iu,
-  ]);
-
-  query = stripTrailingMatch(query, [
-    /[\u3002\uFF0C\uFF01\uFF1F,!.?]?\s*(?:\u5e76|\u7136\u540e|\u518d)?\s*(?:\u628a|\u5c06)?\s*(?:\u7f51\u9875)?\u6807\u9898\u548c\u94fe\u63a5(?:\u544a\u8bc9\u6211|\u7ed9\u6211|\u53d1\u6211)?\s*$/u,
-    /[\u3002\uFF0C\uFF01\uFF1F,!.?]?\s*(?:\u53ea\u8981|\u53ea\u9700\u8981)?\s*(?:\u7f51\u9875)?\u6807\u9898\u548c\u94fe\u63a5\s*$/u,
-    /[\u3002\uFF0C\uFF01\uFF1F,!.?]?\s*(?:\u544a\u8bc9\u6211|\u7ed9\u6211|\u53d1\u6211|\u5217\u51fa\u6765)\s*$/u,
-    /\s*(?:and\s+)?(?:give|tell|show)\s+me\s+(?:the\s+)?title(?:s)?\s+and\s+link(?:s)?\s*$/iu,
-  ]);
-
-  query = collapseSearchTerms(
-    query
-      .replace(/[\u3002\uFF0C\uFF01\uFF1F,!.?]+/gu, " ")
-      .replace(/([\p{Script=Han}])\u5728(?=[A-Za-z0-9])/gu, "$1 ")
-      .replace(/(?<=[\p{Script=Han}])(?=[A-Za-z0-9])/gu, " ")
-      .replace(/(?<=[A-Za-z0-9])(?=[\p{Script=Han}])/gu, " ")
-      .replace(
-        /(?:\u662f\u8c01|\u4ec0\u4e48\u4eba|\u8c01\u554a|\u8c01\u5440|\u4ec0\u4e48\u65f6\u5019|\u5565\u65f6\u5019|\u4f55\u65f6|\u51e0\u70b9|\u51e0\u53f7|\u54ea\u5929|\u4ec0\u4e48\u65f6\u95f4|\u7ed3\u675f|\u622a\u6b62|\u5f00\u59cb|\u5f00\u5e55)/gu,
-        " ",
-      )
-      .replace(/\b(?:who|when|what\s+time|what\s+date)\b/giu, " ")
-      .replace(/[\u201c\u201d"'`\u2018\u2019]+/gu, " "),
-  );
-
-  if (asksWho) {
-    query = appendSearchTerms(query, "\u4eba\u7269 \u7b80\u4ecb");
-  } else if (asksWhen && asksEnd) {
-    query = appendSearchTerms(query, "\u7ed3\u675f\u65f6\u95f4");
-  } else if (asksWhen && asksStart) {
-    query = appendSearchTerms(query, "\u5f00\u59cb\u65f6\u95f4");
-  } else if (asksWhen) {
-    query = appendSearchTerms(query, "\u65f6\u95f4 \u65e5\u671f");
-  }
-
-  return query || originalTask;
-}
-
-function parseWriteCommand(task: string): WriteCommand {
-  const trimmedTask = task.trim();
-  const approveMatch = trimmedTask.match(/^APPROVE_WRITE(?:\s+(\S+))?$/i);
-  if (approveMatch) {
-    return {
-      type: "approve",
-      draftId: approveMatch[1] ?? null,
-    };
-  }
-
-  const cancelMatch = trimmedTask.match(/^CANCEL_WRITE(?:\s+(\S+))?$/i);
-  if (cancelMatch) {
-    return {
-      type: "cancel",
-      draftId: cancelMatch[1] ?? null,
-    };
-  }
-
-  return null;
-}
-
-type DraftLifecycleAction = "approve" | "cancel" | "continue";
-
-function parseDraftLifecycleAction(task: string): DraftLifecycleAction | null {
-  const trimmedTask = task.trim();
-
-  if (!trimmedTask) {
-    return null;
-  }
-
-  if (
-    /^(?:please\s+)?approve(?:\s|$)/i.test(trimmedTask) ||
-    /^(批准|确认写入|批准它|批准这个|批准刚才那个|确认这个draft|确认这个草稿)/.test(
-      trimmedTask,
-    )
-  ) {
-    return "approve";
-  }
-
-  if (
-    /^(?:please\s+)?cancel(?:\s|$)/i.test(trimmedTask) ||
-    /^(取消|丢弃|丢掉|放弃|不要写了|取消它|取消这个|取消刚才那个)/.test(
-      trimmedTask,
-    )
-  ) {
-    return "cancel";
-  }
-
-  if (
-    /^(?:please\s+)?continue(?:\s|$)/i.test(trimmedTask) ||
-    /^(继续|接着|继续上一步|继续刚才那个)/.test(trimmedTask)
-  ) {
-    return "continue";
-  }
-
-  return null;
-}
-
-function isAmbiguousDraftConfirmation(task: string) {
-  const trimmedTask = task.trim().toLowerCase();
-
-  return (
-    /^(ok|okay|yes|yep|go ahead|looks good|approved?)$/.test(trimmedTask) ||
-    /^(?:\u901a\u8fc7|\u597d|\u884c|\u53ef\u4ee5|\u786e\u8ba4|\u6ca1\u95ee\u9898)$/.test(
-      task.trim(),
-    )
-  );
-}
-
-async function handleWriteApproval(task: string): Promise<AgentResponse | null> {
-  const command = parseWriteCommand(task);
-
-  if (!command) {
-    return null;
-  }
-
-  if (!command.draftId) {
-    const commandName =
-      command.type === "approve" ? APPROVE_WRITE_COMMAND : CANCEL_WRITE_COMMAND;
-
-      return {
-        message: createMessage(
-          [
-            "A draft id is required.",
-            `Use the exact format: ${commandName} draft-123`,
-          ].join("\n"),
-        ),
-        sessionContext: {},
-        steps: [
-          createStep(
-            "perceive",
-          "Perceive",
-          "Read a write confirmation command from the user.",
-        ),
-        createStep(
-          "think",
-          "Think",
-          "Check whether the command includes a draft id.",
-        ),
-        createStep(
-          "act",
-          "Act",
-          "Stop here because the command was missing its draft id.",
-        ),
-      ],
-    };
-  }
-
-  if (command.type === "approve") {
-    const pendingDraft = getPendingWriteDraft();
-
-    if (!pendingDraft) {
-      return {
-        message: createMessage("There is no pending write draft to approve."),
-        sessionContext: {},
-        steps: [
-          createStep(
-            "perceive",
-            "Perceive",
-            "Read the approval command from the user.",
-          ),
-          createStep(
-            "think",
-            "Think",
-            "Check whether a pending write draft exists.",
-          ),
-          createStep(
-            "act",
-            "Act",
-            "No draft was waiting, so nothing was written.",
-          ),
-        ],
-      };
-    }
-
-    if (pendingDraft.id !== command.draftId) {
-      return {
-        message: createMessage(
-          [
-            "The draft id did not match the current pending draft.",
-            `Requested id: ${command.draftId}`,
-            `Current pending id: ${pendingDraft.id}`,
-          ].join("\n"),
-        ),
-        sessionContext: {
-          pendingDraft,
-        },
-        steps: [
-          createStep(
-            "perceive",
-            "Perceive",
-            `Read the approval command for draft "${command.draftId}".`,
-          ),
-          createStep(
-            "think",
-            "Think",
-            `Compare the requested id with the current pending draft id "${pendingDraft.id}".`,
-          ),
-          createStep(
-            "act",
-            "Act",
-            "Refuse the write because the draft id did not match.",
-          ),
-        ],
-      };
-    }
-
-    const appliedDraft = await applyPendingWriteDraft();
-
-    return {
-      message: createMessage(
-        [
-          "Write approved and saved.",
-          `Draft id: ${pendingDraft.id}`,
-          `Target path: ${pendingDraft.path}`,
-          "The draft has been written to disk.",
-        ].join("\n"),
-      ),
-      sessionContext: {
-        lastToolInput: pendingDraft.path,
-        lastToolName: "write_file",
-        pendingDraft: null,
-      },
-      steps: [
-        createStep(
-          "perceive",
-          "Perceive",
-          `Read the exact approval command "${APPROVE_WRITE_COMMAND} ${pendingDraft.id}".`,
-        ),
-        createStep(
-          "think",
-          "Think",
-          `Confirm that draft "${pendingDraft.id}" exists for "${pendingDraft.path}".`,
-        ),
-        createStep(
-          "act",
-          "Act",
-          `Write approved draft "${appliedDraft?.id ?? pendingDraft.id}" to "${appliedDraft?.path ?? pendingDraft.path}".`,
-        ),
-      ],
-    };
-  }
-
-  if (command.type === "cancel") {
-    const pendingDraft = getPendingWriteDraft();
-
-    if (!pendingDraft) {
-      return {
-        message: createMessage("There is no pending write draft to discard."),
-        sessionContext: {},
-        steps: [
-          createStep(
-            "perceive",
-            "Perceive",
-            "Read the cancel command from the user.",
-          ),
-          createStep(
-            "think",
-            "Think",
-            "Check whether there is a pending draft to discard.",
-          ),
-          createStep(
-            "act",
-            "Act",
-            "Nothing was waiting, so nothing was cleared.",
-          ),
-        ],
-      };
-    }
-
-    if (pendingDraft.id !== command.draftId) {
-      return {
-        message: createMessage(
-          [
-            "The draft id did not match the current pending draft.",
-            `Requested id: ${command.draftId}`,
-            `Current pending id: ${pendingDraft.id}`,
-          ].join("\n"),
-        ),
-        sessionContext: {
-          pendingDraft,
-        },
-        steps: [
-          createStep(
-            "perceive",
-            "Perceive",
-            `Read the cancel command for draft "${command.draftId}".`,
-          ),
-          createStep(
-            "think",
-            "Think",
-            `Compare the requested id with the current pending draft id "${pendingDraft.id}".`,
-          ),
-          createStep(
-            "act",
-            "Act",
-            "Keep the draft because the cancel id did not match.",
-          ),
-        ],
-      };
-    }
-
-    clearPendingWriteDraft();
-
-    return {
-      message: createMessage(
-        [
-          "Draft discarded.",
-          `Draft id: ${pendingDraft.id}`,
-          `Target path: ${pendingDraft.path}`,
-        ].join("\n"),
-      ),
-      sessionContext: {
-        lastToolInput: pendingDraft.path,
-        lastToolName: "write_file",
-        pendingDraft: null,
-      },
-      steps: [
-        createStep(
-          "perceive",
-          "Perceive",
-          `Read the exact cancel command "${CANCEL_WRITE_COMMAND} ${pendingDraft.id}".`,
-        ),
-        createStep(
-          "think",
-          "Think",
-          `Confirm that draft "${pendingDraft.id}" is the one waiting to be discarded.`,
-        ),
-        createStep(
-          "act",
-          "Act",
-          `Clear draft "${pendingDraft.id}" for "${pendingDraft.path}" without writing it.`,
-        ),
-      ],
-    };
-  }
-
-  return null;
 }
 
 function perceive(context: AgentContext): PerceptionResult {
@@ -2072,10 +400,9 @@ function buildMessagesWithToolRuns(baseMessages: LlmMessage[], toolRuns: ToolRun
 function isFileModificationRequest(task: string) {
   return (
     /(modify|edit|update|change|append|replace|rewrite|revise)/i.test(task) ||
-    /(修改|编辑|更新|改|追加|替换|重写|删除|增加)/.test(task)
+    /(修改|编辑|更新|改动|追加|替换|重写|删除|增加)/u.test(task)
   );
 }
-
 async function think(
   context: AgentContext,
   perception: PerceptionResult,
@@ -2192,6 +519,8 @@ async function think(
             "If the user asks for the current repository issue list, prefer git_inspect with action issue_list.",
             "If the user asks for current GitHub repository info, prefer git_inspect with action repo_info.",
             "If the user asks for a PR draft suggestion, prefer git_inspect with action pr_draft.",
+            "If the user asks to export a patch, generate patch text, or produce a diff patch, prefer git_inspect with action patch_export. This is read-only and must not commit or push.",
+            "If the user asks for a task_submit draft or task submit text, prefer git_inspect with action task_submit. This is read-only and must not commit, push, or actually submit anything.",
             "If the user asks for a commit message suggestion, prefer git_inspect with action commit_message.",
             "If the user asks whether the workspace is connected to GitHub, or asks about remotes, GitHub remotes, gh CLI, or GitHub login readiness, prefer git_inspect with action github_env.",
             "If the user asks for git status or repository status, prefer git_inspect with action status.",
@@ -2211,6 +540,9 @@ async function think(
         {
           role: "user",
           content: [
+            "Older conversation summary:",
+            formatConversationSummaryForModel(context.sessionContext),
+            "",
             "Recent conversation:",
             formatConversationForModel(context.recentConversation),
             "",
@@ -2296,6 +628,9 @@ async function thinkAfterReadForModification(
         {
           role: "user",
           content: [
+            "Older conversation summary:",
+            formatConversationSummaryForModel(context.sessionContext),
+            "",
             "Recent conversation:",
             formatConversationForModel(context.recentConversation),
             "",
@@ -2493,6 +828,9 @@ async function answerWithToolResults(
       {
         role: "user",
         content: [
+          "Older conversation summary:",
+          formatConversationSummaryForModel(context.sessionContext),
+          "",
           "Recent conversation:",
           formatConversationForModel(context.recentConversation),
           "",
@@ -2523,6 +861,9 @@ async function answerDirectly(context: AgentContext, goal: string) {
     {
       role: "user",
       content: [
+        "Older conversation summary:",
+        formatConversationSummaryForModel(context.sessionContext),
+        "",
         "Recent conversation:",
         formatConversationForModel(context.recentConversation),
         "",
@@ -2535,30 +876,6 @@ async function answerDirectly(context: AgentContext, goal: string) {
   ]);
 
   return response;
-}
-
-async function runToolCall(
-  toolName: string,
-  toolInput: ToolExecutionInput,
-  toolCallId: string,
-  assistantMessage: LlmMessage,
-): Promise<ToolRun> {
-  const tool = getTool(toolName);
-  if (!tool) {
-    throw new Error(`Tool "${toolName}" is not registered.`);
-  }
-
-  const result = await tool.execute(toolInput);
-  const inputText = formatToolExecutionInput(toolInput);
-
-  return {
-    assistantMessage,
-    name: toolName,
-    input: toolInput,
-    inputText,
-    result,
-    toolCallId,
-  };
 }
 
 export async function runAgent(
@@ -2786,11 +1103,18 @@ export async function runAgent(
     throw new Error("Missing DEEPSEEK_API_KEY.");
   }
 
+  const model = process.env.DEEPSEEK_MODEL ?? "deepseek-v4-flash";
+  const preparedConversationContext = await prepareConversationContext(
+    model,
+    messages,
+    task,
+    effectiveSessionContext,
+  );
   const context: AgentContext = {
     cleanTask: task.trim(),
-    model: process.env.DEEPSEEK_MODEL ?? "deepseek-v4-flash",
-    recentConversation: normalizeConversationHistory(messages, task),
-    sessionContext: effectiveSessionContext,
+    model,
+    recentConversation: preparedConversationContext.recentConversation,
+    sessionContext: preparedConversationContext.sessionContext,
     toolNames: listTools().map((tool) => tool.name),
   };
 
@@ -2850,7 +1174,7 @@ export async function runAgent(
                 content: thought.directAnswer,
                 reasoning_content: thought.assistantMessage?.reasoning_content ?? null,
               }
-            : 
+            :
             (await answerWithToolResults(context, perception.goal, toolRuns));
 
       await pushStep(
@@ -2872,8 +1196,8 @@ export async function runAgent(
           message: createMessage(reply.content, reply.reasoning_content),
           sessionContext:
             toolRuns.length === 0
-              ? effectiveSessionContext
-              : buildNextSessionContext(effectiveSessionContext, toolRuns),
+              ? context.sessionContext
+              : buildNextSessionContext(context.sessionContext, toolRuns),
           steps,
         },
         false,
@@ -2940,7 +1264,7 @@ export async function runAgent(
       return finishWithLogging(
         {
           message: createMessage(immediateOutcome.message),
-          sessionContext: buildNextSessionContext(effectiveSessionContext, toolRuns),
+          sessionContext: buildNextSessionContext(context.sessionContext, toolRuns),
           steps,
         },
         false,
@@ -2962,7 +1286,7 @@ export async function runAgent(
       return finishWithLogging(
         {
           message: createMessage(finalReply.content, finalReply.reasoning_content),
-          sessionContext: buildNextSessionContext(effectiveSessionContext, toolRuns),
+          sessionContext: buildNextSessionContext(context.sessionContext, toolRuns),
           steps,
         },
         false,

--- a/src/lib/agent/session-state.ts
+++ b/src/lib/agent/session-state.ts
@@ -1,0 +1,57 @@
+import type { AgentSessionContext } from "@/types/agent";
+import { getToolPathReference } from "@/lib/agent/tool-args";
+import type { ToolRun } from "@/lib/agent/tool-run-types";
+
+export function formatSessionContextForModel(
+  sessionContext: AgentSessionContext,
+) {
+  const lines = [
+    `Last tool name: ${sessionContext.lastToolName ?? "none"}`,
+    `Last tool input: ${sessionContext.lastToolInput ?? "none"}`,
+    `Last listed directory: ${sessionContext.lastListedDirectoryPath ?? "none"}`,
+    `Last read file: ${sessionContext.lastReadFilePath ?? "none"}`,
+  ];
+
+  if (sessionContext.pendingDraft) {
+    lines.push(`Pending draft id: ${sessionContext.pendingDraft.id}`);
+    lines.push(`Pending draft path: ${sessionContext.pendingDraft.path}`);
+    lines.push("Pending draft content:");
+    lines.push(sessionContext.pendingDraft.content || "(empty file)");
+  } else {
+    lines.push("Pending draft id: none");
+  }
+
+  lines.push(
+    "Reference rules: if the user says 'that draft', prefer the pending draft. If the user says 'that file', prefer the pending draft path first, then the last read file. If the user says 'continue the last step', prefer continuing the pending draft flow; otherwise use the last tool context.",
+  );
+
+  return lines.join("\n");
+}
+
+export function buildNextSessionContext(
+  previousContext: AgentSessionContext,
+  toolRuns: ToolRun[],
+): AgentSessionContext {
+  const nextContext: AgentSessionContext = {
+    ...previousContext,
+  };
+
+  for (const toolRun of toolRuns) {
+    nextContext.lastToolName = toolRun.name;
+    nextContext.lastToolInput = toolRun.inputText;
+
+    if (toolRun.name === "list_files") {
+      nextContext.lastListedDirectoryPath = getToolPathReference(toolRun.input);
+    }
+
+    if (toolRun.name === "read_file") {
+      nextContext.lastReadFilePath = getToolPathReference(toolRun.input);
+    }
+
+    if (toolRun.result.draft) {
+      nextContext.pendingDraft = toolRun.result.draft;
+    }
+  }
+
+  return nextContext;
+}

--- a/src/lib/agent/tool-args.ts
+++ b/src/lib/agent/tool-args.ts
@@ -1,0 +1,59 @@
+import type { ToolCallArgs, ToolExecutionInput } from "@/lib/tools/types";
+import type { ToolRun } from "@/lib/agent/tool-run-types";
+
+export function parseTagBlock(text: string, tagName: string) {
+  const pattern = new RegExp(`<${tagName}>([\\s\\S]*?)</${tagName}>`);
+  const match = text.match(pattern);
+  return match?.[1]?.trim() ?? null;
+}
+
+export function getStringArg(args: ToolCallArgs, key: string) {
+  const value = args[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function getStringArrayArg(args: ToolCallArgs, key: string) {
+  const value = args[key];
+
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+export function getNumberArg(args: ToolCallArgs, key: string) {
+  const value = args[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export function getToolPathReference(input: ToolExecutionInput) {
+  if (typeof input === "string") {
+    return input.trim() || null;
+  }
+
+  return getStringArg(input, "path") || null;
+}
+
+export function formatToolExecutionInput(input: ToolExecutionInput) {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  return JSON.stringify(input);
+}
+
+export function formatToolRunsForModel(toolRuns: ToolRun[]) {
+  return toolRuns
+    .map((toolRun, index) =>
+      [
+        `Tool result ${index + 1}:`,
+        `name: ${toolRun.name}`,
+        `input: ${toolRun.inputText}`,
+        `ok: ${toolRun.result.ok ? "true" : "false"}`,
+        "content:",
+        toolRun.result.content,
+      ].join("\n"),
+    )
+    .join("\n\n");
+}

--- a/src/lib/agent/tool-run-types.ts
+++ b/src/lib/agent/tool-run-types.ts
@@ -1,0 +1,25 @@
+import type { ToolExecutionInput, ToolResult } from "@/lib/tools/types";
+import type { LlmMessage } from "@/lib/agent/model-client";
+
+export type DirectToolPlan = {
+  id: string;
+  input: ToolExecutionInput;
+  name: string;
+};
+
+export type ToolRun = {
+  assistantMessage: LlmMessage;
+  input: ToolExecutionInput;
+  inputText: string;
+  name: string;
+  result: ToolResult;
+  toolCallId: string;
+};
+
+export const APPROVE_WRITE_COMMAND = "APPROVE_WRITE";
+export const CANCEL_WRITE_COMMAND = "CANCEL_WRITE";
+export const MAX_TOOL_CALLS = 4;
+
+export function createSyntheticToolCallId() {
+  return `tool-call-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}

--- a/src/lib/agent/tool-runner.ts
+++ b/src/lib/agent/tool-runner.ts
@@ -1,0 +1,29 @@
+import { getTool } from "@/lib/tools/tool-registry";
+import type { ToolExecutionInput } from "@/lib/tools/types";
+import { formatToolExecutionInput } from "@/lib/agent/tool-args";
+import type { LlmMessage } from "@/lib/agent/model-client";
+import type { ToolRun } from "@/lib/agent/tool-run-types";
+
+export async function runToolCall(
+  toolName: string,
+  toolInput: ToolExecutionInput,
+  toolCallId: string,
+  assistantMessage: LlmMessage,
+): Promise<ToolRun> {
+  const tool = getTool(toolName);
+  if (!tool) {
+    throw new Error(`Tool "${toolName}" is not registered.`);
+  }
+
+  const result = await tool.execute(toolInput);
+  const inputText = formatToolExecutionInput(toolInput);
+
+  return {
+    assistantMessage,
+    name: toolName,
+    input: toolInput,
+    inputText,
+    result,
+    toolCallId,
+  };
+}

--- a/src/lib/tools/git-inspect.ts
+++ b/src/lib/tools/git-inspect.ts
@@ -9,6 +9,7 @@ import { getWorkspaceRoot } from "@/lib/tools/workspace-path";
 
 const execFileAsync = promisify(execFile);
 const MAX_DIFF_PREVIEW_LENGTH = 12_000;
+const MAX_PATCH_EXPORT_LENGTH = 200_000;
 const GH_CLI_EXECUTABLE = process.env.GH_PATH?.trim() || "gh";
 
 type GitInspectAction =
@@ -19,6 +20,8 @@ type GitInspectAction =
   | "github_env"
   | "commit_message"
   | "pr_draft"
+  | "patch_export"
+  | "task_submit"
   | "repo_info"
   | "issue_list"
   | "issue_detail"
@@ -49,6 +52,7 @@ type GitInspectReport = {
   issuePlan: string | null;
   isGitRepository: boolean;
   message: string;
+  patchText: string | null;
   prDraftSuggestion: string | null;
   repoInfo: string | null;
   remoteEntries: string[];
@@ -56,6 +60,7 @@ type GitInspectReport = {
   summaryText: string | null;
   status: "success" | "failed" | "rejected";
   statusEntries: string[];
+  taskSubmitDraft: string | null;
   workspaceRoot: string;
 };
 
@@ -74,10 +79,12 @@ function createGitInspectReport(
     | "issueList"
     | "issuePlan"
     | "remoteEntries"
+    | "patchText"
     | "prDraftSuggestion"
     | "repoInfo"
     | "summaryText"
     | "statusEntries"
+    | "taskSubmitDraft"
   > & {
     branch?: string | null;
     commitMessageSuggestion?: string | null;
@@ -90,11 +97,13 @@ function createGitInspectReport(
     issueDetail?: string | null;
     issueList?: string | null;
     issuePlan?: string | null;
+    patchText?: string | null;
     prDraftSuggestion?: string | null;
     repoInfo?: string | null;
     remoteEntries?: string[];
     summaryText?: string | null;
     statusEntries?: string[];
+    taskSubmitDraft?: string | null;
   },
 ): GitInspectReport {
   return {
@@ -109,11 +118,13 @@ function createGitInspectReport(
     issueDetail: report.issueDetail ?? null,
     issueList: report.issueList ?? null,
     issuePlan: report.issuePlan ?? null,
+    patchText: report.patchText ?? null,
     prDraftSuggestion: report.prDraftSuggestion ?? null,
     repoInfo: report.repoInfo ?? null,
     remoteEntries: report.remoteEntries ?? [],
     summaryText: report.summaryText ?? null,
     statusEntries: report.statusEntries ?? [],
+    taskSubmitDraft: report.taskSubmitDraft ?? null,
     ...report,
   };
 }
@@ -143,10 +154,14 @@ function formatGitInspectReport(report: GitInspectReport) {
     report.issuePlan ?? "(none)",
     "repo_info:",
     report.repoInfo ?? "(none)",
+    "patch_text:",
+    report.patchText ?? "(none)",
     "pr_draft_suggestion:",
     report.prDraftSuggestion ?? "(none)",
     "summary_text:",
     report.summaryText ?? "(none)",
+    "task_submit_draft:",
+    report.taskSubmitDraft ?? "(none)",
     "github_readiness_missing:",
     report.githubReadinessMissing.length > 0
       ? report.githubReadinessMissing.join("\n")
@@ -165,7 +180,7 @@ function parseGitInspectInput(input: ToolExecutionInput): ParsedGitInspectInput 
     return {
       ok: false,
       message:
-        'git_inspect expects object input like {"action":"check_repo"}, {"action":"status"}, {"action":"diff"}, {"action":"summary"}, {"action":"github_env"}, {"action":"commit_message"}, {"action":"pr_draft"}, {"action":"repo_info"}, {"action":"issue_list"}, {"action":"issue_detail","issue_number":123}, or {"action":"issue_plan","issue_text":"..."}; plain string input is not supported.',
+        'git_inspect expects object input like {"action":"check_repo"}, {"action":"status"}, {"action":"diff"}, {"action":"summary"}, {"action":"github_env"}, {"action":"commit_message"}, {"action":"pr_draft"}, {"action":"patch_export"}, {"action":"task_submit"}, {"action":"repo_info"}, {"action":"issue_list"}, {"action":"issue_detail","issue_number":123}, or {"action":"issue_plan","issue_text":"..."}; plain string input is not supported.',
     };
   }
 
@@ -179,6 +194,8 @@ function parseGitInspectInput(input: ToolExecutionInput): ParsedGitInspectInput 
     action !== "github_env" &&
     action !== "commit_message" &&
     action !== "pr_draft" &&
+    action !== "patch_export" &&
+    action !== "task_submit" &&
     action !== "repo_info" &&
     action !== "issue_list" &&
     action !== "issue_detail" &&
@@ -187,7 +204,7 @@ function parseGitInspectInput(input: ToolExecutionInput): ParsedGitInspectInput 
     return {
       ok: false,
       message:
-        'git_inspect currently allows only {"action":"check_repo"}, {"action":"status"}, {"action":"diff"}, {"action":"summary"}, {"action":"github_env"}, {"action":"commit_message"}, {"action":"pr_draft"}, {"action":"repo_info"}, {"action":"issue_list"}, {"action":"issue_detail"}, or {"action":"issue_plan"} as input.',
+        'git_inspect currently allows only {"action":"check_repo"}, {"action":"status"}, {"action":"diff"}, {"action":"summary"}, {"action":"github_env"}, {"action":"commit_message"}, {"action":"pr_draft"}, {"action":"patch_export"}, {"action":"task_submit"}, {"action":"repo_info"}, {"action":"issue_list"}, {"action":"issue_detail"}, or {"action":"issue_plan"} as input.',
     };
   }
 
@@ -353,6 +370,69 @@ function trimDiffPreview(diffText: string) {
   }
 
   return `${diffText.slice(0, MAX_DIFF_PREVIEW_LENGTH)}\n[diff preview truncated]`;
+}
+
+function trimPatchExport(patchText: string) {
+  if (patchText.length <= MAX_PATCH_EXPORT_LENGTH) {
+    return {
+      patchText,
+      truncated: false,
+    };
+  }
+
+  return {
+    patchText: `${patchText.slice(0, MAX_PATCH_EXPORT_LENGTH)}\n[patch export truncated]`,
+    truncated: true,
+  };
+}
+
+function isMissingHeadError(error: unknown) {
+  const message = String(
+    (error as { message?: unknown })?.message ??
+      (error as { stderr?: unknown })?.stderr ??
+      "",
+  ).toLowerCase();
+
+  return (
+    message.includes("bad revision 'head'") ||
+    message.includes("ambiguous argument 'head'") ||
+    message.includes("unknown revision or path not in the working tree")
+  );
+}
+
+async function runDiffAgainstHead(
+  workspaceRoot: string,
+  diffArgs: string[],
+) {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["diff", "--no-ext-diff", ...diffArgs, "HEAD", "--"],
+      {
+        cwd: workspaceRoot,
+        maxBuffer: 8 * 1024 * 1024,
+        windowsHide: true,
+      },
+    );
+
+    return stdout;
+  } catch (error) {
+    if (!isMissingHeadError(error)) {
+      throw error;
+    }
+
+    const { stdout } = await execFileAsync(
+      "git",
+      ["diff", "--no-ext-diff", ...diffArgs, "--"],
+      {
+        cwd: workspaceRoot,
+        maxBuffer: 8 * 1024 * 1024,
+        windowsHide: true,
+      },
+    );
+
+    return stdout;
+  }
 }
 
 type ParsedRemoteEntry = {
@@ -732,6 +812,57 @@ function suggestPrDraft(
   return [title, "", ...bodyLines].join("\n");
 }
 
+function suggestTaskSubmitDraft(
+  branch: string | null,
+  statusEntries: string[],
+  diffStatLines: string[],
+  patchText: string,
+  patchTruncated: boolean,
+) {
+  if (statusEntries.length === 0) {
+    return "No task_submit draft is available because there are no local changes.";
+  }
+
+  const counts = countStatusChanges(statusEntries);
+  const changedPaths = parseChangedPaths(statusEntries);
+  const uniquePaths = [...new Set(changedPaths.map((item) => item.path))];
+  const summary = summarizeGitChanges(branch, statusEntries, diffStatLines);
+  const bodyLines = [
+    "task_submit draft",
+    "",
+    "Summary:",
+    `- ${summary}`,
+    `- Change mix: ${counts.staged} staged, ${counts.unstaged} unstaged, ${counts.untracked} untracked.`,
+  ];
+
+  if (uniquePaths.length > 0) {
+    bodyLines.push(`- Key paths: ${uniquePaths.slice(0, 8).join(", ")}`);
+  }
+
+  bodyLines.push("");
+  bodyLines.push("Testing:");
+  bodyLines.push("- Not run yet");
+  bodyLines.push("");
+  bodyLines.push("Patch:");
+
+  if (patchText) {
+    bodyLines.push("```diff");
+    bodyLines.push(patchText);
+    bodyLines.push("```");
+  } else {
+    bodyLines.push(
+      "(No tracked patch text is available. Untracked files can appear in status, but this read-only draft does not stage or commit them.)",
+    );
+  }
+
+  if (patchTruncated) {
+    bodyLines.push("");
+    bodyLines.push("Note: Patch text was truncated to keep the tool output bounded.");
+  }
+
+  return bodyLines.join("\n");
+}
+
 function formatIssueList(
   issues: Array<{
     number?: number | null;
@@ -949,6 +1080,10 @@ function pickIssueKeywordsForDisplay(keywords: string[]) {
 }
 
 function buildStructuredIssuePlan(issueText: string) {
+  if (!issueText.trim()) {
+    return buildIssuePlan(issueText);
+  }
+
   const { title, body } = extractIssueTitleAndBody(issueText);
   const candidatePaths = extractIssuePaths(issueText);
   const keywords = extractIssueKeywords(title, body);
@@ -1553,6 +1688,192 @@ async function runPrDraftAction(): Promise<ToolResult> {
       content: formatGitInspectReport(
         createGitInspectReport({
           action: "pr_draft",
+          isGitRepository: false,
+          message,
+          repositoryRoot: null,
+          status: "failed",
+          workspaceRoot,
+        }),
+      ),
+    };
+  }
+}
+
+async function loadPatchExportContext(workspaceRoot: string) {
+  const [{ stdout: statusStdout }, diffStatStdout, patchStdout] =
+    await Promise.all([
+      execFileAsync("git", ["status", "--short", "--branch"], {
+        cwd: workspaceRoot,
+        maxBuffer: 1024 * 1024,
+        windowsHide: true,
+      }),
+      runDiffAgainstHead(workspaceRoot, ["--stat"]),
+      runDiffAgainstHead(workspaceRoot, ["--binary"]),
+    ]);
+
+  const parsedStatus = parseGitStatusOutput(statusStdout);
+  const diffStatLines = diffStatStdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const patchExport = trimPatchExport(patchStdout.trim());
+
+  return {
+    diffStatLines,
+    parsedStatus,
+    patchExport,
+  };
+}
+
+async function runPatchExportAction(): Promise<ToolResult> {
+  const workspaceRoot = getWorkspaceRoot();
+
+  try {
+    const repositoryRoot = await getRepositoryRoot(workspaceRoot);
+    const { diffStatLines, parsedStatus, patchExport } =
+      await loadPatchExportContext(workspaceRoot);
+    const hasChanges = parsedStatus.statusEntries.length > 0;
+
+    return {
+      ok: true,
+      content: formatGitInspectReport(
+        createGitInspectReport({
+          action: "patch_export",
+          branch: parsedStatus.branch,
+          diffPreview:
+            diffStatLines.length > 0 ? diffStatLines.join("\n") : "no tracked diff stat",
+          isGitRepository: true,
+          message: hasChanges
+            ? patchExport.patchText
+              ? "Patch export created from local tracked changes. This action only reads git diff and does not commit or push."
+              : "Patch export completed, but no tracked patch text is available. Untracked files are listed in status but are not staged by this read-only action."
+            : "Patch export completed. The working tree is clean.",
+          patchText: patchExport.patchText || "no tracked patch text",
+          repositoryRoot,
+          status: "success",
+          statusEntries: hasChanges
+            ? parsedStatus.statusEntries
+            : ["clean working tree"],
+          summaryText: summarizeGitChanges(
+            parsedStatus.branch,
+            parsedStatus.statusEntries,
+            diffStatLines,
+          ),
+          workspaceRoot,
+        }),
+      ),
+    };
+  } catch (error) {
+    if (isNotGitRepositoryError(error)) {
+      return {
+        ok: true,
+        content: formatGitInspectReport(
+          createGitInspectReport({
+            action: "patch_export",
+            isGitRepository: false,
+            message:
+              "Patch export is not available because the current workspace is not a Git repository yet.",
+            patchText: "No patch export is available because this workspace is not a Git repository yet.",
+            repositoryRoot: null,
+            status: "success",
+            workspaceRoot,
+          }),
+        ),
+      };
+    }
+
+    const message =
+      (error as { message?: string })?.message ??
+      "git_inspect failed while exporting the patch text.";
+
+    return {
+      ok: false,
+      content: formatGitInspectReport(
+        createGitInspectReport({
+          action: "patch_export",
+          isGitRepository: false,
+          message,
+          repositoryRoot: null,
+          status: "failed",
+          workspaceRoot,
+        }),
+      ),
+    };
+  }
+}
+
+async function runTaskSubmitAction(): Promise<ToolResult> {
+  const workspaceRoot = getWorkspaceRoot();
+
+  try {
+    const repositoryRoot = await getRepositoryRoot(workspaceRoot);
+    const { diffStatLines, parsedStatus, patchExport } =
+      await loadPatchExportContext(workspaceRoot);
+    const taskSubmitDraft = suggestTaskSubmitDraft(
+      parsedStatus.branch,
+      parsedStatus.statusEntries,
+      diffStatLines,
+      patchExport.patchText,
+      patchExport.truncated,
+    );
+
+    return {
+      ok: true,
+      content: formatGitInspectReport(
+        createGitInspectReport({
+          action: "task_submit",
+          branch: parsedStatus.branch,
+          diffPreview:
+            diffStatLines.length > 0 ? diffStatLines.join("\n") : "no tracked diff stat",
+          isGitRepository: true,
+          message:
+            "task_submit draft created from local Git facts. This action only reads status and diff; it does not commit, push, or submit anything.",
+          patchText: patchExport.patchText || "no tracked patch text",
+          repositoryRoot,
+          status: "success",
+          statusEntries:
+            parsedStatus.statusEntries.length > 0
+              ? parsedStatus.statusEntries
+              : ["clean working tree"],
+          summaryText: summarizeGitChanges(
+            parsedStatus.branch,
+            parsedStatus.statusEntries,
+            diffStatLines,
+          ),
+          taskSubmitDraft,
+          workspaceRoot,
+        }),
+      ),
+    };
+  } catch (error) {
+    if (isNotGitRepositoryError(error)) {
+      return {
+        ok: true,
+        content: formatGitInspectReport(
+          createGitInspectReport({
+            action: "task_submit",
+            isGitRepository: false,
+            message:
+              "task_submit draft is not available because the current workspace is not a Git repository yet.",
+            repositoryRoot: null,
+            status: "success",
+            taskSubmitDraft:
+              "No task_submit draft is available because this workspace is not a Git repository yet.",
+            workspaceRoot,
+          }),
+        ),
+      };
+    }
+
+    const message =
+      (error as { message?: string })?.message ??
+      "git_inspect failed while building the task_submit draft.";
+
+    return {
+      ok: false,
+      content: formatGitInspectReport(
+        createGitInspectReport({
+          action: "task_submit",
           isGitRepository: false,
           message,
           repositoryRoot: null,
@@ -2218,6 +2539,14 @@ async function executeGitInspect(input: ToolExecutionInput): Promise<ToolResult>
     return runPrDraftAction();
   }
 
+  if (parsed.action === "patch_export") {
+    return runPatchExportAction();
+  }
+
+  if (parsed.action === "task_submit") {
+    return runTaskSubmitAction();
+  }
+
   if (parsed.action === "repo_info") {
     return runRepoInfoAction();
   }
@@ -2236,14 +2565,14 @@ async function executeGitInspect(input: ToolExecutionInput): Promise<ToolResult>
 export const gitInspectTool: AgentTool = {
   name: "git_inspect",
   description:
-    "Check Git and GitHub environment facts for the current workspace. MVP actions: detect whether the workspace is inside a Git repository, read git status, read a minimal git diff preview, produce a short local change summary, inspect GitHub readiness such as remotes and gh CLI availability, suggest a commit message draft, suggest a PR draft description, read basic GitHub repository info, list repository issues, read one issue detail, and turn either pasted issue text or one GitHub issue number into a minimal execution plan.",
+    "Check Git and GitHub environment facts for the current workspace. MVP actions: detect whether the workspace is inside a Git repository, read git status, read a minimal git diff preview, produce a short local change summary, inspect GitHub readiness such as remotes and gh CLI availability, suggest a commit message draft, suggest a PR draft description, export read-only git diff patch text, draft a read-only task_submit response, read basic GitHub repository info, list repository issues, read one issue detail, and turn either pasted issue text or one GitHub issue number into a minimal execution plan.",
   inputSchema: {
     type: "object",
     properties: {
       action: {
         type: "string",
         description:
-          'Required Git inspection action. Current MVP supports "check_repo", "status", "diff", "summary", "github_env", "commit_message", "pr_draft", "repo_info", "issue_list", "issue_detail", or "issue_plan".',
+          'Required Git inspection action. Current MVP supports "check_repo", "status", "diff", "summary", "github_env", "commit_message", "pr_draft", "patch_export", "task_submit", "repo_info", "issue_list", "issue_detail", or "issue_plan".',
       },
       issue_number: {
         type: "number",

--- a/src/lib/tools/read-file.ts
+++ b/src/lib/tools/read-file.ts
@@ -1,41 +1,184 @@
 import { readFile } from "node:fs/promises";
 import type {
   AgentTool,
+  ToolCallArgs,
   ToolExecutionInput,
   ToolResult,
 } from "@/lib/tools/types";
 import { resolveWorkspacePath } from "@/lib/tools/workspace-path";
 
-function parseReadFileInput(input: ToolExecutionInput) {
+const DEFAULT_MAX_LINES = 500;
+const MAX_LINES_LIMIT = 1000;
+
+type ParsedReadFileInput =
+  | {
+      ok: true;
+      maxLines: number;
+      path: string;
+      startLine: number;
+    }
+  | {
+      ok: false;
+      message: string;
+    };
+
+function getOptionalLineNumber(input: ToolCallArgs, key: string) {
+  const value = input[key];
+
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    return {
+      ok: false,
+      message: `"${key}" must be a whole number.`,
+    } as const;
+  }
+
+  if (value < 1) {
+    return {
+      ok: false,
+      message: `"${key}" must be greater than or equal to 1.`,
+    } as const;
+  }
+
+  return {
+    ok: true,
+    value,
+  } as const;
+}
+
+function parseReadFileInput(input: ToolExecutionInput): ParsedReadFileInput {
   if (typeof input === "string") {
-    return input.trim();
+    const path = input.trim();
+
+    if (!path) {
+      return {
+        ok: false,
+        message: "read_file needs a non-empty file path.",
+      };
+    }
+
+    return {
+      ok: true,
+      maxLines: DEFAULT_MAX_LINES,
+      path,
+      startLine: 1,
+    };
   }
 
-  if (typeof input.path === "string") {
-    return input.path.trim();
+  const path = typeof input.path === "string" ? input.path.trim() : "";
+
+  if (!path) {
+    return {
+      ok: false,
+      message: 'read_file needs a non-empty "path" value.',
+    };
   }
 
-  return "";
+  const startLine = getOptionalLineNumber(input, "start_line");
+  if (startLine?.ok === false) {
+    return startLine;
+  }
+
+  const maxLines = getOptionalLineNumber(input, "max_lines");
+  if (maxLines?.ok === false) {
+    return maxLines;
+  }
+
+  if (maxLines !== null && maxLines.value > MAX_LINES_LIMIT) {
+    return {
+      ok: false,
+      message: `"max_lines" must be less than or equal to ${MAX_LINES_LIMIT}.`,
+    };
+  }
+
+  return {
+    ok: true,
+    maxLines: maxLines?.value ?? DEFAULT_MAX_LINES,
+    path,
+    startLine: startLine?.value ?? 1,
+  };
+}
+
+function splitFileLines(fileContent: string) {
+  if (fileContent.length === 0) {
+    return [];
+  }
+
+  const lines = fileContent.split(/\r?\n/);
+
+  if (lines.length > 1 && lines.at(-1) === "") {
+    lines.pop();
+  }
+
+  return lines;
+}
+
+function formatNumberedWindow(
+  lines: string[],
+  parsed: Extract<ParsedReadFileInput, { ok: true }>,
+): ToolResult {
+  if (lines.length === 0) {
+    return {
+      ok: true,
+      content: `File: ${parsed.path}\nLines: 0 of 0\n\n(empty file)`,
+    };
+  }
+
+  if (parsed.startLine > lines.length) {
+    return {
+      ok: false,
+      content: `"start_line" is beyond the end of the file. ${parsed.path} has ${lines.length} line(s).`,
+    };
+  }
+
+  const startIndex = parsed.startLine - 1;
+  const endIndexExclusive = Math.min(startIndex + parsed.maxLines, lines.length);
+  const lineNumberWidth = String(endIndexExclusive).length;
+  const numberedLines = lines
+    .slice(startIndex, endIndexExclusive)
+    .map((line, index) => {
+      const lineNumber = String(parsed.startLine + index).padStart(
+        lineNumberWidth,
+        " ",
+      );
+
+      return `${lineNumber} | ${line}`;
+    });
+
+  const shownEndLine = endIndexExclusive;
+  const truncated = shownEndLine < lines.length;
+  const header = [
+    `File: ${parsed.path}`,
+    `Lines: ${parsed.startLine}-${shownEndLine} of ${lines.length}`,
+    truncated
+      ? `Output truncated. Use start_line=${shownEndLine + 1} to continue.`
+      : null,
+  ].filter((line): line is string => line !== null);
+
+  return {
+    ok: true,
+    content: `${header.join("\n")}\n\n${numberedLines.join("\n")}`,
+  };
 }
 
 async function executeReadFile(input: ToolExecutionInput): Promise<ToolResult> {
-  const filePath = parseReadFileInput(input);
+  const parsed = parseReadFileInput(input);
 
-  if (!filePath) {
+  if (!parsed.ok) {
     return {
       ok: false,
-      content: "A file path is required.",
+      content: parsed.message,
     };
   }
 
   try {
-    const targetPath = resolveWorkspacePath(filePath);
+    const targetPath = resolveWorkspacePath(parsed.path);
     const fileContent = await readFile(targetPath, "utf8");
 
-    return {
-      ok: true,
-      content: fileContent,
-    };
+    return formatNumberedWindow(splitFileLines(fileContent), parsed);
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "The file could not be read.";
@@ -49,13 +192,23 @@ async function executeReadFile(input: ToolExecutionInput): Promise<ToolResult> {
 
 export const readFileTool: AgentTool = {
   name: "read_file",
-  description: "Read one UTF-8 text file from the configured workspace root.",
+  description:
+    "Read a UTF-8 text file from the configured workspace root with line numbers and optional line-window limits.",
   inputSchema: {
     type: "object",
     properties: {
       path: {
         type: "string",
         description: "Required file path relative to the configured workspace root.",
+      },
+      start_line: {
+        type: "number",
+        description:
+          "Optional 1-based line number to start reading from. Defaults to 1.",
+      },
+      max_lines: {
+        type: "number",
+        description: `Optional number of lines to read. Defaults to ${DEFAULT_MAX_LINES}; maximum ${MAX_LINES_LIMIT}.`,
       },
     },
     required: ["path"],

--- a/src/lib/tools/safe-command.ts
+++ b/src/lib/tools/safe-command.ts
@@ -7,8 +7,8 @@ import type {
   ToolCallArgs,
   ToolExecutionInput,
   ToolResult,
-} from "@/lib/tools/types";
-import { getWorkspaceRoot, resolveWorkspacePath } from "@/lib/tools/workspace-path";
+} from "./types";
+import { getWorkspaceRoot, resolveWorkspacePath } from "./workspace-path";
 
 const execFileAsync = promisify(execFile);
 const MAX_OUTPUT_LENGTH = 8_000;
@@ -276,6 +276,23 @@ function buildAllowedNpmCall(args: string[]): SafeCommandPlan {
     };
   }
 
+  if (args.length === 2 && args[0] === "run" && args[1] === "lint") {
+    if (!workspaceHasNpmScript("lint")) {
+      return {
+        ok: false,
+        message:
+          'safe_command checked package.json and did not find a "lint" script, so npm run lint is not allowed in this workspace.',
+      };
+    }
+
+    return {
+      ok: true,
+      commandText: "npm run lint",
+      executable: "npm",
+      executableArgs: ["run", "lint"],
+    };
+  }
+
   if (args.length === 1 && args[0] === "test") {
     if (!workspaceHasNpmScript("test")) {
       return {
@@ -296,7 +313,7 @@ function buildAllowedNpmCall(args: string[]): SafeCommandPlan {
   return {
     ok: false,
     message:
-      'safe_command currently allows only npm run build, or npm test when package.json includes a test script.',
+      'safe_command currently allows only npm run build, npm run lint when package.json includes a lint script, or npm test when package.json includes a test script.',
   };
 }
 
@@ -452,7 +469,7 @@ async function executeSafeCommand(input: ToolExecutionInput): Promise<ToolResult
 export const safeCommandTool: AgentTool = {
   name: "safe_command",
   description:
-    "Run one whitelisted local command inside the current workspace. MVP allowlist: rg search, rg --files, git status, npm run build, and npm test only when package.json includes a test script.",
+    "Run one whitelisted local command inside the current workspace. MVP allowlist: rg search, rg --files, git status, npm run build, npm run lint only when package.json includes a lint script, and npm test only when package.json includes a test script.",
   inputSchema: {
     type: "object",
     properties: {
@@ -473,4 +490,8 @@ export const safeCommandTool: AgentTool = {
     additionalProperties: false,
   },
   execute: executeSafeCommand,
+};
+
+export const __safeCommandTestInternals = {
+  buildAllowedCommandCall,
 };

--- a/src/lib/tools/web-search.ts
+++ b/src/lib/tools/web-search.ts
@@ -210,7 +210,11 @@ function rerankResults(query: string, results: SearchResultItem[]) {
       return left.index - right.index;
     })
     .slice(0, MAX_RESULTS)
-    .map(({ index: _index, score: _score, ...result }) => result);
+    .map((result) => ({
+      description: result.description,
+      link: result.link,
+      title: result.title,
+    }));
 }
 
 function formatResults(query: string, results: DisplaySearchResultItem[]) {
@@ -228,7 +232,10 @@ function formatResults(query: string, results: DisplaySearchResultItem[]) {
 }
 
 function toDisplayResults(results: SearchResultItem[]): DisplaySearchResultItem[] {
-  return results.map(({ description: _description, ...result }) => result);
+  return results.map((result) => ({
+    link: result.link,
+    title: result.title,
+  }));
 }
 
 function parseWebSearchInput(input: ToolExecutionInput) {

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -15,6 +15,7 @@ export type PendingDraftSnapshot = {
 };
 
 export type AgentSessionContext = {
+  conversationSummary?: string | null;
   lastListedDirectoryPath?: string | null;
   lastReadFilePath?: string | null;
   lastToolInput?: string | null;

--- a/test/safe-command.test.ts
+++ b/test/safe-command.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { __safeCommandTestInternals, safeCommandTool } from "../src/lib/tools/safe-command";
+
+const { buildAllowedCommandCall } = __safeCommandTestInternals;
+
+function withWorkspaceRoot<T>(workspaceRoot: string, callback: () => T): T {
+  const previousRoot = process.env.AGENT_WORKSPACE_ROOT;
+  process.env.AGENT_WORKSPACE_ROOT = workspaceRoot;
+
+  try {
+    return callback();
+  } finally {
+    if (previousRoot === undefined) {
+      delete process.env.AGENT_WORKSPACE_ROOT;
+    } else {
+      process.env.AGENT_WORKSPACE_ROOT = previousRoot;
+    }
+  }
+}
+
+test("safe_command allows the MVP command allowlist", () => {
+  withWorkspaceRoot(process.cwd(), () => {
+    assert.equal(buildAllowedCommandCall("git", ["status"]).ok, true);
+    assert.equal(buildAllowedCommandCall("rg", ["--files"]).ok, true);
+    assert.equal(buildAllowedCommandCall("rg", ["safe_command", "src"]).ok, true);
+    assert.equal(buildAllowedCommandCall("npm", ["run", "build"]).ok, true);
+    assert.equal(buildAllowedCommandCall("npm", ["run", "lint"]).ok, true);
+    assert.equal(buildAllowedCommandCall("npm", ["test"]).ok, true);
+  });
+});
+
+test("safe_command rejects npm run lint when the workspace has no lint script", () => {
+  const workspaceRoot = mkdtempSync(path.join(tmpdir(), "thrush-safe-command-"));
+  writeFileSync(
+    path.join(workspaceRoot, "package.json"),
+    JSON.stringify({ scripts: { test: "node --test" } }),
+  );
+
+  withWorkspaceRoot(workspaceRoot, () => {
+    const result = buildAllowedCommandCall("npm", ["run", "lint"]);
+
+    assert.equal(result.ok, false);
+    assert.match(result.message, /did not find a "lint" script/);
+  });
+});
+
+test("safe_command rejects commands outside the allowlist", async () => {
+  const blockedShell = await safeCommandTool.execute({
+    command: "powershell",
+    args: ["Get-ChildItem"],
+  });
+  const unknownCommand = await safeCommandTool.execute({
+    command: "ls",
+    args: [],
+  });
+  const customRgFlag = buildAllowedCommandCall("rg", ["--hidden"]);
+  const unsupportedNpmScript = buildAllowedCommandCall("npm", ["run", "dev"]);
+
+  assert.equal(blockedShell.ok, false);
+  assert.match(blockedShell.content, /blocked for safety/);
+  assert.equal(unknownCommand.ok, false);
+  assert.match(unknownCommand.content, /not in the safe_command allowlist/);
+  assert.equal(customRgFlag.ok, false);
+  assert.equal(unsupportedNpmScript.ok, false);
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": false,
+    "isolatedModules": false,
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "noEmit": false,
+    "outDir": "./.test-dist",
+    "types": ["node"]
+  },
+  "include": [
+    "src/lib/tools/safe-command.ts",
+    "src/lib/tools/types.ts",
+    "src/lib/tools/workspace-path.ts",
+    "test/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## What changed

- Refactored the agent runtime so `run-agent.ts` is smaller and easier to maintain.
- Added focused agent modules for model calls, context compression, response streaming, draft lifecycle, direct tool routing, issue flow, page result formatting, session state, tool args, and tool execution.
- Improved tool coverage for line-window file reading, patch/task submit inspection, safe command validation, and backend-managed conversation context.
- Added ESLint flat config and a focused safe_command test suite.

## Why

The previous agent entry file carried too many responsibilities in one place. Splitting it into focused modules makes the code easier to upgrade without touching the main loop every time.

## Validation

- `npx tsc --noEmit`
- `npm run lint`
- `npm test`
- `npm run build` with a dummy non-empty `DEEPSEEK_API_KEY`
- `git diff --check`
- secret scan for `sk-` style keys