### PR TITLE
Add project session workspace workbench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,9 @@
 .env.development.local
 .env.test.local
 .env.production.local
-data/drafts.db
+data/*.db
+data/*.db-shm
+data/*.db-wal
 data/workspace/**
 !data/workspace/.gitkeep
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,5 +5,6 @@ export default function nextConfig(phase: string): NextConfig {
   return {
     distDir: phase === PHASE_DEVELOPMENT_SERVER ? ".next-dev" : ".next",
     reactStrictMode: true,
+    serverExternalPackages: ["better-sqlite3"],
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "thrush-swe-agent",
       "version": "0.1.0",
       "dependencies": {
+        "better-sqlite3": "^12.10.0",
         "next": "^15.3.0",
         "openai": "^6.39.0",
         "playwright": "^1.60.0",
@@ -17,6 +18,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
         "@playwright/test": "^1.60.0",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^22.15.30",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
@@ -1055,6 +1057,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -2024,6 +2036,60 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
@@ -2046,6 +2112,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/call-bind": {
@@ -2144,6 +2234,12 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -2279,6 +2375,30 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2327,7 +2447,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2366,6 +2485,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
@@ -2964,6 +3092,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3038,6 +3175,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3104,6 +3247,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -3239,6 +3388,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -3390,6 +3545,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3426,6 +3601,18 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -4060,6 +4247,18 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -4077,11 +4276,16 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4107,6 +4311,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -4181,6 +4391,18 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-exports-info": {
@@ -4333,6 +4555,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/openai": {
@@ -4551,6 +4782,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4571,6 +4829,16 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -4604,6 +4872,30 @@
       ],
       "license": "MIT"
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
@@ -4631,6 +4923,20 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -4775,6 +5081,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -4820,7 +5146,6 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
       "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5022,6 +5347,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5050,6 +5420,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -5237,6 +5616,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -5329,6 +5736,18 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5509,6 +5928,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5623,6 +6048,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "tsc -p tsconfig.test.json && node --test .test-dist/test/safe-command.test.js"
   },
   "dependencies": {
+    "better-sqlite3": "^12.10.0",
     "next": "^15.3.0",
     "openai": "^6.39.0",
     "playwright": "^1.60.0",
@@ -19,6 +20,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
     "@playwright/test": "^1.60.0",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.15.30",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",

--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -1,9 +1,18 @@
 import { NextResponse } from "next/server";
 import { runAgent } from "@/lib/agent/run-agent";
+import {
+  appendMessage,
+  createCheckpoint,
+  getSessionProject,
+  recordToolRun,
+  updateSessionState,
+} from "@/lib/db/store";
 import { createLogger } from "@/lib/logger";
+import { withWorkspaceRoot } from "@/lib/tools/workspace-path";
 import type { AgentRequest, AgentStreamEvent } from "@/types/agent";
 
 const encoder = new TextEncoder();
+export const runtime = "nodejs";
 
 function serializeStreamEvent(event: AgentStreamEvent | { type: "error"; message: string }) {
   return encoder.encode(`data: ${JSON.stringify(event)}\n\n`);
@@ -50,14 +59,89 @@ export async function POST(request: Request) {
     );
   }
 
+  const sessionId = body.sessionId?.trim();
+  if (!sessionId) {
+    return NextResponse.json(
+      { error: "sessionId is required." },
+      { status: 400 },
+    );
+  }
+
+  const sessionProject = getSessionProject(sessionId);
+  if (!sessionProject) {
+    return NextResponse.json(
+      { error: "Session was not found." },
+      { status: 404 },
+    );
+  }
+
+  const { project, session } = sessionProject;
+  const userMessage = appendMessage({
+    content: task,
+    role: "user",
+    sessionId,
+  });
+  const messagesForAgent = [...session.messages, userMessage];
+  const sessionContext = {
+    ...session.sessionContext,
+    projectId: project.id,
+    sessionId,
+  };
+
+  createCheckpoint({
+    data: {
+      task,
+      projectId: project.id,
+      workspacePath: project.workspacePath,
+    },
+    kind: "agent_started",
+    requestId,
+    sessionId,
+  });
+
   if (body.stream) {
     const stream = new ReadableStream<Uint8Array>({
       async start(controller) {
         try {
-          await runAgent(task, body.messages, body.sessionContext, requestId, {
-            onEvent(event) {
-              controller.enqueue(serializeStreamEvent(event));
+          const result = await withWorkspaceRoot(project.workspacePath, () =>
+            runAgent(task, messagesForAgent, sessionContext, requestId, {
+              onEvent(event) {
+                controller.enqueue(serializeStreamEvent(event));
+              },
+              onToolRun(toolRun) {
+                recordToolRun({
+                  requestId,
+                  sessionId,
+                  toolRun,
+                });
+                createCheckpoint({
+                  data: toolRun,
+                  kind: "tool_completed",
+                  requestId,
+                  sessionId,
+                });
+              },
+              projectId: project.id,
+              sessionId,
+              workspaceRoot: project.workspacePath,
+            }),
+          );
+
+          appendMessage({
+            content: result.message.content,
+            reasoningContent: result.message.reasoning_content ?? null,
+            role: "assistant",
+            sessionId,
+          });
+          updateSessionState(sessionId, result.sessionContext, result.steps);
+          createCheckpoint({
+            data: {
+              sessionContext: result.sessionContext,
+              steps: result.steps,
             },
+            kind: "agent_finished",
+            requestId,
+            sessionId,
           });
           logger.info("agent request completed", {
             durationMs: Date.now() - startTime,
@@ -90,12 +174,38 @@ export async function POST(request: Request) {
   }
 
   try {
-    const result = await runAgent(
-      task,
-      body.messages,
-      body.sessionContext,
-      requestId,
+    const result = await withWorkspaceRoot(
+      project.workspacePath,
+      () =>
+        runAgent(task, messagesForAgent, sessionContext, requestId, {
+          onToolRun(toolRun) {
+            recordToolRun({
+              requestId,
+              sessionId,
+              toolRun,
+            });
+          },
+          projectId: project.id,
+          sessionId,
+          workspaceRoot: project.workspacePath,
+        }),
     );
+    appendMessage({
+      content: result.message.content,
+      reasoningContent: result.message.reasoning_content ?? null,
+      role: "assistant",
+      sessionId,
+    });
+    updateSessionState(sessionId, result.sessionContext, result.steps);
+    createCheckpoint({
+      data: {
+        sessionContext: result.sessionContext,
+        steps: result.steps,
+      },
+      kind: "agent_finished",
+      requestId,
+      sessionId,
+    });
     logger.info("agent request completed", {
       durationMs: Date.now() - startTime,
     });

--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { runAgent } from "@/lib/agent/run-agent";
 import {
+  getEffectiveWorkspacePath,
+  handleWorkspaceSwitchTask,
+} from "@/lib/agent/workspace-switch";
+import {
   appendMessage,
   createCheckpoint,
   getSessionProject,
@@ -16,6 +20,27 @@ export const runtime = "nodejs";
 
 function serializeStreamEvent(event: AgentStreamEvent | { type: "error"; message: string }) {
   return encoder.encode(`data: ${JSON.stringify(event)}\n\n`);
+}
+
+function createImmediateStream(events: AgentStreamEvent[]) {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const event of events) {
+          controller.enqueue(serializeStreamEvent(event));
+        }
+
+        controller.close();
+      },
+    }),
+    {
+      headers: {
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+        "Content-Type": "text/event-stream; charset=utf-8",
+      },
+    },
+  );
 }
 
 export async function POST(request: Request) {
@@ -87,12 +112,64 @@ export async function POST(request: Request) {
     projectId: project.id,
     sessionId,
   };
+  const workspaceSwitchResult = handleWorkspaceSwitchTask({
+    projectId: project.id,
+    projectWorkspacePath: project.workspacePath,
+    sessionContext,
+    sessionId,
+    task,
+  });
+
+  if (workspaceSwitchResult.handled) {
+    const assistantMessage = appendMessage({
+      content: workspaceSwitchResult.message,
+      role: "assistant",
+      sessionId,
+    });
+
+    updateSessionState(
+      sessionId,
+      workspaceSwitchResult.sessionContext,
+      workspaceSwitchResult.steps,
+    );
+    createCheckpoint({
+      data: {
+        task,
+        sessionContext: workspaceSwitchResult.sessionContext,
+        steps: workspaceSwitchResult.steps,
+      },
+      kind: "workspace_switch_handled",
+      requestId,
+      sessionId,
+    });
+
+    const result = {
+      message: assistantMessage,
+      sessionContext: workspaceSwitchResult.sessionContext,
+      steps: workspaceSwitchResult.steps,
+    };
+
+    if (body.stream) {
+      return createImmediateStream([
+        { type: "steps", steps: result.steps },
+        { type: "message", message: result.message },
+        { type: "done", sessionContext: result.sessionContext },
+      ]);
+    }
+
+    return NextResponse.json(result);
+  }
+
+  const effectiveWorkspacePath = getEffectiveWorkspacePath(
+    sessionContext,
+    project.workspacePath,
+  );
 
   createCheckpoint({
     data: {
       task,
       projectId: project.id,
-      workspacePath: project.workspacePath,
+      workspacePath: effectiveWorkspacePath,
     },
     kind: "agent_started",
     requestId,
@@ -103,7 +180,7 @@ export async function POST(request: Request) {
     const stream = new ReadableStream<Uint8Array>({
       async start(controller) {
         try {
-          const result = await withWorkspaceRoot(project.workspacePath, () =>
+          const result = await withWorkspaceRoot(effectiveWorkspacePath, () =>
             runAgent(task, messagesForAgent, sessionContext, requestId, {
               onEvent(event) {
                 controller.enqueue(serializeStreamEvent(event));
@@ -123,7 +200,7 @@ export async function POST(request: Request) {
               },
               projectId: project.id,
               sessionId,
-              workspaceRoot: project.workspacePath,
+              workspaceRoot: effectiveWorkspacePath,
             }),
           );
 
@@ -175,7 +252,7 @@ export async function POST(request: Request) {
 
   try {
     const result = await withWorkspaceRoot(
-      project.workspacePath,
+      effectiveWorkspacePath,
       () =>
         runAgent(task, messagesForAgent, sessionContext, requestId, {
           onToolRun(toolRun) {
@@ -187,7 +264,7 @@ export async function POST(request: Request) {
           },
           projectId: project.id,
           sessionId,
-          workspaceRoot: project.workspacePath,
+          workspaceRoot: effectiveWorkspacePath,
         }),
     );
     appendMessage({

--- a/src/app/api/projects/[projectId]/sessions/route.ts
+++ b/src/app/api/projects/[projectId]/sessions/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { createSession, ensureWorkbench } from "@/lib/db/store";
+
+export const runtime = "nodejs";
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ projectId: string }> },
+) {
+  const { projectId } = await context.params;
+  let body: { title?: unknown } = {};
+
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  try {
+    const session = createSession(
+      projectId,
+      typeof body.title === "string" && body.title.trim()
+        ? body.title.trim()
+        : "New session",
+    );
+
+    return NextResponse.json({
+      session,
+      snapshot: ensureWorkbench(),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Session could not be created." },
+      { status: 400 },
+    );
+  }
+}

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { createProject, ensureWorkbench } from "@/lib/db/store";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  return NextResponse.json(ensureWorkbench());
+}
+
+export async function POST(request: Request) {
+  let body: {
+    confirmWorkspace?: unknown;
+    name?: unknown;
+    workspacePath?: unknown;
+  };
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Request body must be valid JSON." },
+      { status: 400 },
+    );
+  }
+
+  const workspacePath =
+    typeof body.workspacePath === "string" ? body.workspacePath.trim() : "";
+
+  if (!workspacePath) {
+    return NextResponse.json(
+      { error: "workspacePath is required." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const project = createProject({
+      confirmWorkspace: body.confirmWorkspace === true,
+      name: typeof body.name === "string" ? body.name : "",
+      workspacePath,
+    });
+
+    return NextResponse.json({
+      project,
+      snapshot: ensureWorkbench(),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Project could not be created." },
+      { status: 400 },
+    );
+  }
+}

--- a/src/app/api/sessions/[sessionId]/route.ts
+++ b/src/app/api/sessions/[sessionId]/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/db/store";
+
+export const runtime = "nodejs";
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ sessionId: string }> },
+) {
+  const { sessionId } = await context.params;
+  const session = getSession(sessionId);
+
+  if (!session) {
+    return NextResponse.json(
+      { error: "Session was not found." },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({ session });
+}

--- a/src/app/api/sessions/[sessionId]/tool-runs/route.ts
+++ b/src/app/api/sessions/[sessionId]/tool-runs/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { listToolRuns } from "@/lib/db/store";
+
+export const runtime = "nodejs";
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ sessionId: string }> },
+) {
+  const { sessionId } = await context.params;
+
+  return NextResponse.json({
+    toolRuns: listToolRuns(sessionId),
+  });
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,6 +10,8 @@
   --muted-soft: #8f8375;
   --accent: #c76d43;
   --accent-deep: #8f4b2d;
+  --nav: #263238;
+  --nav-soft: #e7eef0;
   --line: rgba(125, 103, 82, 0.16);
   --line-strong: rgba(125, 103, 82, 0.28);
   --shadow: 0 24px 60px rgba(58, 39, 24, 0.08);
@@ -91,9 +93,10 @@ textarea {
   font-size: 0.84rem;
 }
 
+.workbench-grid,
 .workspace-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.55fr) minmax(320px, 0.88fr);
+  grid-template-columns: 280px minmax(0, 1.45fr) minmax(320px, 0.78fr);
   gap: 20px;
   align-items: start;
 }
@@ -116,6 +119,17 @@ textarea {
   padding: 24px;
 }
 
+.sidebar-panel {
+  position: sticky;
+  top: 24px;
+  display: grid;
+  align-content: start;
+  gap: 18px;
+  max-height: calc(100vh - 48px);
+  overflow: auto;
+  padding: 20px;
+}
+
 .trace-panel {
   position: sticky;
   top: 24px;
@@ -124,11 +138,135 @@ textarea {
   padding: 24px;
 }
 
+.sidebar-header {
+  display: grid;
+  gap: 14px;
+}
+
+.sidebar-header h2 {
+  margin: 6px 0 0;
+  font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", serif;
+  font-size: 1.4rem;
+  letter-spacing: -0.02em;
+}
+
 .panel-header h2 {
   margin: 6px 0 0;
   font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", serif;
   font-size: clamp(1.8rem, 2vw, 2.4rem);
   letter-spacing: -0.03em;
+}
+
+.session-subtitle {
+  max-width: 100%;
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 0.84rem;
+  overflow-wrap: anywhere;
+}
+
+.project-list,
+.session-list {
+  display: grid;
+  gap: 10px;
+}
+
+.project-group {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(255, 253, 248, 0.82);
+}
+
+.project-row,
+.session-row,
+.new-session-button,
+.small-button {
+  border: 1px solid var(--line);
+  cursor: pointer;
+  transition:
+    background 140ms ease,
+    border-color 140ms ease,
+    transform 140ms ease;
+}
+
+.project-row {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  gap: 8px;
+  align-items: center;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  font-weight: 700;
+}
+
+.project-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-path {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.76rem;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.session-list {
+  padding-left: 20px;
+}
+
+.session-row,
+.new-session-button,
+.small-button {
+  width: 100%;
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: rgba(245, 249, 249, 0.86);
+  color: var(--nav);
+  text-align: left;
+  font-size: 0.86rem;
+}
+
+.session-row.active {
+  border-color: rgba(38, 50, 56, 0.42);
+  background: var(--nav);
+  color: #f7fbfb;
+}
+
+.new-session-button {
+  background: var(--nav-soft);
+  color: var(--nav);
+  font-weight: 700;
+}
+
+.small-button {
+  background: var(--nav);
+  color: #f7fbfb;
+  text-align: center;
+  font-weight: 700;
+}
+
+.project-row:hover,
+.session-row:hover,
+.new-session-button:hover,
+.small-button:hover {
+  transform: translateY(-1px);
+}
+
+.project-row:disabled,
+.session-row:disabled,
+.new-session-button:disabled,
+.small-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
 }
 
 .panel-kicker {
@@ -657,10 +795,12 @@ textarea {
 }
 
 @media (max-width: 1100px) {
+  .workbench-grid,
   .workspace-grid {
     grid-template-columns: 1fr;
   }
 
+  .sidebar-panel,
   .trace-panel {
     position: static;
     max-height: none;
@@ -687,6 +827,7 @@ textarea {
   }
 
   .chat-panel,
+  .sidebar-panel,
   .trace-panel {
     padding: 20px;
     border-radius: 24px;

--- a/src/components/chat/chat-shell.tsx
+++ b/src/components/chat/chat-shell.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import Image from "next/image";
-import { FormEvent, useLayoutEffect, useRef, useState } from "react";
+import {
+  FormEvent,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type {
   AgentRequest,
   AgentSessionContext,
@@ -9,13 +16,18 @@ import type {
   AgentStreamEvent,
   ChatMessage,
 } from "@/types/agent";
+import type {
+  ProjectSummary,
+  SessionDetail,
+  WorkbenchSnapshot,
+} from "@/types/workbench";
 
 const starterMessages: ChatMessage[] = [
   {
     id: "welcome",
     role: "assistant",
     content:
-      "I am Thrush. Give me a task and I will show how the loop will work.",
+      "I am Thrush. Pick a project session, then give me a task for that workspace.",
   },
 ];
 
@@ -53,25 +65,18 @@ const thinkingFragments = ["top", "right", "bottom", "left"] as const;
 const agentApiSecret = process.env.NEXT_PUBLIC_AGENT_API_SECRET?.trim();
 
 type AgentErrorEvent = {
-  type: "error";
   message: string;
+  type: "error";
 };
 
 async function readBackendErrorMessage(response: Response) {
   const fallbackMessage = `The backend API returned HTTP ${response.status}.`;
 
   try {
-    const contentType = response.headers.get("content-type") ?? "";
-
-    if (contentType.includes("application/json")) {
-      const payload = (await response.json()) as { error?: unknown };
-      return typeof payload.error === "string" && payload.error.trim()
-        ? payload.error.trim()
-        : fallbackMessage;
-    }
-
-    const text = (await response.text()).trim();
-    return text || fallbackMessage;
+    const payload = (await response.json()) as { error?: unknown };
+    return typeof payload.error === "string" && payload.error.trim()
+      ? payload.error.trim()
+      : fallbackMessage;
   } catch {
     return fallbackMessage;
   }
@@ -102,14 +107,56 @@ function parseStreamEvent(rawChunk: string) {
   return JSON.parse(payload) as AgentStreamEvent | AgentErrorEvent;
 }
 
+function formatWorkspacePath(project: ProjectSummary | null) {
+  return project?.workspacePath.replace(/\\/g, "/") ?? "No workspace selected";
+}
+
 export function ChatShell() {
+  const [snapshot, setSnapshot] = useState<WorkbenchSnapshot>({
+    activeSessionId: null,
+    projects: [],
+  });
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const [activeSession, setActiveSession] = useState<SessionDetail | null>(null);
+  const [expandedProjectIds, setExpandedProjectIds] = useState<Set<string>>(
+    () => new Set(),
+  );
   const [input, setInput] = useState("");
-  const [messages, setMessages] = useState<ChatMessage[]>(starterMessages);
-  const [sessionContext, setSessionContext] = useState<AgentSessionContext>({});
-  const [steps, setSteps] = useState<AgentStep[]>(starterSteps);
   const [isLoading, setIsLoading] = useState(false);
+  const [isBooting, setIsBooting] = useState(true);
   const messageViewportRef = useRef<HTMLDivElement | null>(null);
+
+  const activeProject = useMemo(() => {
+    if (!activeSession) {
+      return null;
+    }
+
+    return (
+      snapshot.projects.find((project) => project.id === activeSession.projectId) ??
+      null
+    );
+  }, [activeSession, snapshot.projects]);
+
+  const messages = activeSession?.messages.length
+    ? activeSession.messages
+    : starterMessages;
+  const steps = activeSession?.steps.length ? activeSession.steps : starterSteps;
+  const sessionContext: AgentSessionContext =
+    activeSession?.sessionContext ?? {};
   const pendingDraft = sessionContext.pendingDraft;
+
+  useEffect(() => {
+    void loadWorkbench();
+  }, []);
+
+  useEffect(() => {
+    if (!activeSessionId) {
+      setActiveSession(null);
+      return;
+    }
+
+    void loadSession(activeSessionId);
+  }, [activeSessionId]);
 
   useLayoutEffect(() => {
     const viewport = messageViewportRef.current;
@@ -120,19 +167,55 @@ export function ChatShell() {
     viewport.scrollTop = viewport.scrollHeight;
   }, [messages]);
 
+  async function loadWorkbench(selectSessionId?: string) {
+    const response = await fetch("/api/projects");
+    if (!response.ok) {
+      throw new Error(await readBackendErrorMessage(response));
+    }
+
+    const nextSnapshot = (await response.json()) as WorkbenchSnapshot;
+    setSnapshot(nextSnapshot);
+    setExpandedProjectIds(
+      new Set(nextSnapshot.projects.map((project) => project.id)),
+    );
+    setActiveSessionId(selectSessionId ?? nextSnapshot.activeSessionId);
+    setIsBooting(false);
+  }
+
+  async function loadSession(sessionId: string) {
+    const response = await fetch(`/api/sessions/${sessionId}`);
+    if (!response.ok) {
+      throw new Error(await readBackendErrorMessage(response));
+    }
+
+    const payload = (await response.json()) as { session: SessionDetail };
+    setActiveSession(payload.session);
+  }
+
+  function patchActiveSession(patch: Partial<SessionDetail>) {
+    setActiveSession((current) => (current ? { ...current, ...patch } : current));
+  }
+
   function applyStreamEvent(event: AgentStreamEvent | AgentErrorEvent) {
     if (event.type === "steps") {
-      setSteps(event.steps);
+      patchActiveSession({ steps: event.steps });
       return;
     }
 
     if (event.type === "message") {
-      setMessages((current) => [...current, event.message]);
+      setActiveSession((current) =>
+        current
+          ? {
+              ...current,
+              messages: [...current.messages, event.message],
+            }
+          : current,
+      );
       return;
     }
 
     if (event.type === "done") {
-      setSessionContext(event.sessionContext);
+      patchActiveSession({ sessionContext: event.sessionContext });
       return;
     }
 
@@ -163,20 +246,13 @@ export function ChatShell() {
       for (const chunk of chunks) {
         const event = parseStreamEvent(chunk);
 
-        if (!event) {
-          continue;
+        if (event) {
+          applyStreamEvent(event);
         }
-
-        applyStreamEvent(event);
       }
     }
 
-    const finalChunk = buffer.trim();
-    if (!finalChunk) {
-      return;
-    }
-
-    const finalEvent = parseStreamEvent(finalChunk);
+    const finalEvent = parseStreamEvent(buffer.trim());
     if (finalEvent) {
       applyStreamEvent(finalEvent);
     }
@@ -185,31 +261,29 @@ export function ChatShell() {
   async function submitTask(task: string, displayTask = task) {
     const cleanTask = task.trim();
     const cleanDisplayTask = displayTask.trim();
-    if (!cleanTask || !cleanDisplayTask || isLoading) {
+    if (!cleanTask || !cleanDisplayTask || isLoading || !activeSession) {
       return;
     }
 
-    const timestamp = Date.now();
     const userMessage: ChatMessage = {
-      id: `user-${timestamp}`,
+      id: `local-user-${Date.now()}`,
       role: "user",
       content: cleanDisplayTask,
     };
 
-    const nextMessages = [...messages, userMessage];
-
-    setMessages(nextMessages);
-    setSteps(loadingSteps);
+    setActiveSession({
+      ...activeSession,
+      messages: [...activeSession.messages, userMessage],
+      steps: loadingSteps,
+    });
     setInput("");
-
     setIsLoading(true);
 
     try {
       const payload: AgentRequest = {
-        task: cleanTask,
-        messages: nextMessages,
-        sessionContext,
+        sessionId: activeSession.id,
         stream: true,
+        task: cleanTask,
       };
       const response = await fetch("/api/agent", {
         method: "POST",
@@ -227,41 +301,45 @@ export function ChatShell() {
       }
 
       await readAgentStream(response);
+      await loadWorkbench(activeSession.id);
     } catch (error) {
       const errorMessage = getRequestFailureMessage(error);
 
-      setMessages((current) => [
-        ...current,
-        {
-          id: `assistant-error-${Date.now()}`,
-          role: "assistant",
-          content:
-            [
-              "The request failed.",
-              errorMessage,
-            ].join("\n"),
-        },
-      ]);
-      setSteps([
-        {
-          id: "perceive",
-          title: "Perceive",
-          detail: `Tried to send the task "${cleanDisplayTask}" to the backend API.`,
-          status: "done",
-        },
-        {
-          id: "think",
-          title: "Think",
-          detail: `The request failed with this reason: ${errorMessage}`,
-          status: "done",
-        },
-        {
-          id: "act",
-          title: "Act",
-          detail: "Show an error message in the chat window.",
-          status: "done",
-        },
-      ]);
+      setActiveSession((current) =>
+        current
+          ? {
+              ...current,
+              messages: [
+                ...current.messages,
+                {
+                  id: `assistant-error-${Date.now()}`,
+                  role: "assistant",
+                  content: ["The request failed.", errorMessage].join("\n"),
+                },
+              ],
+              steps: [
+                {
+                  id: "perceive",
+                  title: "Perceive",
+                  detail: `Tried to send the task "${cleanDisplayTask}" to the backend API.`,
+                  status: "done",
+                },
+                {
+                  id: "think",
+                  title: "Think",
+                  detail: `The request failed with this reason: ${errorMessage}`,
+                  status: "done",
+                },
+                {
+                  id: "act",
+                  title: "Act",
+                  detail: "Show an error message in the chat window.",
+                  status: "done",
+                },
+              ],
+            }
+          : current,
+      );
     } finally {
       setIsLoading(false);
     }
@@ -286,6 +364,101 @@ export function ChatShell() {
     await submitTask(task, displayTask);
   }
 
+  async function createProjectFromPrompt() {
+    if (isLoading) {
+      return;
+    }
+
+    const workspacePath = window.prompt(
+      "Enter the absolute folder path for this project workspace.",
+    );
+    if (!workspacePath?.trim()) {
+      return;
+    }
+
+    const name =
+      window.prompt("Project name", workspacePath.trim().split(/[\\/]/).pop()) ??
+      "New project";
+
+    const confirmed = window.confirm(
+      `Confirm this workspace path?\n\n${workspacePath.trim()}\n\nAgent tools will be limited to this folder.`,
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    const response = await fetch("/api/projects", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        confirmWorkspace: true,
+        name,
+        workspacePath,
+      }),
+    });
+
+    if (!response.ok) {
+      window.alert(await readBackendErrorMessage(response));
+      return;
+    }
+
+    const payload = (await response.json()) as WorkbenchSnapshot & {
+      snapshot?: WorkbenchSnapshot;
+    };
+    const nextSnapshot = payload.snapshot ?? payload;
+    const createdSessionId =
+      nextSnapshot.projects[0]?.sessions[0]?.id ?? nextSnapshot.activeSessionId;
+
+    setSnapshot(nextSnapshot);
+    setActiveSessionId(createdSessionId ?? null);
+  }
+
+  async function createSessionForProject(projectId: string) {
+    if (isLoading) {
+      return;
+    }
+
+    const response = await fetch(`/api/projects/${projectId}/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "New session" }),
+    });
+
+    if (!response.ok) {
+      window.alert(await readBackendErrorMessage(response));
+      return;
+    }
+
+    const payload = (await response.json()) as {
+      session: SessionDetail;
+      snapshot: WorkbenchSnapshot;
+    };
+    setSnapshot(payload.snapshot);
+    setActiveSessionId(payload.session.id);
+  }
+
+  function toggleProject(projectId: string) {
+    setExpandedProjectIds((current) => {
+      const next = new Set(current);
+
+      if (next.has(projectId)) {
+        next.delete(projectId);
+      } else {
+        next.add(projectId);
+      }
+
+      return next;
+    });
+  }
+
+  function selectSession(sessionId: string) {
+    if (isLoading || sessionId === activeSessionId) {
+      return;
+    }
+
+    setActiveSessionId(sessionId);
+  }
+
   return (
     <main className="app-shell">
       <header className="brand-bar" aria-label="Thrush brand">
@@ -301,30 +474,103 @@ export function ChatShell() {
         </div>
         <div className="brand-copy">
           <p className="brand-name">Thrush</p>
-          <p className="brand-tagline">Agent workspace</p>
+          <p className="brand-tagline">Project session workbench</p>
         </div>
       </header>
 
-      <section className="workspace-grid">
-        <div className="panel chat-panel">
+      <section className="workbench-grid">
+        <aside className="panel sidebar-panel">
+          <div className="sidebar-header">
+            <div>
+              <p className="panel-kicker">Projects</p>
+              <h2>Workspaces</h2>
+            </div>
+            <button
+              className="small-button"
+              type="button"
+              disabled={isLoading}
+              onClick={() => void createProjectFromPrompt()}
+            >
+              + Project
+            </button>
+          </div>
+
+          <div className="project-list">
+            {snapshot.projects.map((project) => {
+              const isExpanded = expandedProjectIds.has(project.id);
+
+              return (
+                <article key={project.id} className="project-group">
+                  <button
+                    className="project-row"
+                    type="button"
+                    disabled={isLoading}
+                    onClick={() => toggleProject(project.id)}
+                  >
+                    <span>{isExpanded ? "v" : ">"}</span>
+                    <span className="project-title">{project.name}</span>
+                  </button>
+                  <p className="workspace-path">{formatWorkspacePath(project)}</p>
+
+                  {isExpanded ? (
+                    <div className="session-list">
+                      {project.sessions.map((session) => (
+                        <button
+                          key={session.id}
+                          className={`session-row ${
+                            session.id === activeSessionId ? "active" : ""
+                          }`}
+                          type="button"
+                          disabled={isLoading}
+                          onClick={() => selectSession(session.id)}
+                        >
+                          {session.title}
+                        </button>
+                      ))}
+
+                      <button
+                        className="new-session-button"
+                        type="button"
+                        disabled={isLoading}
+                        onClick={() => void createSessionForProject(project.id)}
+                      >
+                        + Session
+                      </button>
+                    </div>
+                  ) : null}
+                </article>
+              );
+            })}
+          </div>
+        </aside>
+
+        <section className="panel chat-panel">
           <div className="panel-header">
             <div>
               <p className="panel-kicker">Chat</p>
-              <h2>Task feed</h2>
+              <h2>{activeSession?.title ?? "No session"}</h2>
+              <p className="session-subtitle">{formatWorkspacePath(activeProject)}</p>
             </div>
           </div>
 
           <div ref={messageViewportRef} className="message-viewport">
             <div className="message-list">
-              {messages.map((message) => (
-                <article
-                  key={message.id}
-                  className={`message-bubble ${message.role}`}
-                >
-                  <p className="message-role">{message.role}</p>
-                  <p>{message.content}</p>
+              {isBooting ? (
+                <article className="message-bubble assistant">
+                  <p className="message-role">assistant</p>
+                  <p>Loading workbench...</p>
                 </article>
-              ))}
+              ) : (
+                messages.map((message) => (
+                  <article
+                    key={message.id}
+                    className={`message-bubble ${message.role}`}
+                  >
+                    <p className="message-role">{message.role}</p>
+                    <p>{message.content}</p>
+                  </article>
+                ))
+              )}
 
               {isLoading ? (
                 <article className="message-bubble assistant thinking-bubble">
@@ -383,17 +629,21 @@ export function ChatShell() {
                 id="task-input"
                 className="composer-input"
                 rows={3}
-                disabled={isLoading}
+                disabled={isLoading || !activeSession}
                 value={input}
                 onChange={(event) => setInput(event.target.value)}
-                placeholder="Example: read the README, then suggest the first 3 files I should create."
+                placeholder="Example: read the README, then summarize it."
               />
-              <button className="composer-button" type="submit" disabled={isLoading}>
+              <button
+                className="composer-button"
+                type="submit"
+                disabled={isLoading || !activeSession}
+              >
                 {isLoading ? "Sending..." : "Send task"}
               </button>
             </div>
           </form>
-        </div>
+        </section>
 
         <aside className="panel trace-panel">
           <div className="panel-header">
@@ -405,10 +655,7 @@ export function ChatShell() {
 
           <div className="step-list">
             {steps.map((step) => (
-              <article
-                key={step.id}
-                className={`step-card ${step.status}`}
-              >
+              <article key={step.id} className={`step-card ${step.status}`}>
                 <div className="step-card-content">
                   <div className="step-topline">
                     <h3>{step.title}</h3>

--- a/src/components/chat/chat-shell.tsx
+++ b/src/components/chat/chat-shell.tsx
@@ -111,6 +111,16 @@ function formatWorkspacePath(project: ProjectSummary | null) {
   return project?.workspacePath.replace(/\\/g, "/") ?? "No workspace selected";
 }
 
+function formatActiveWorkspacePath(
+  project: ProjectSummary | null,
+  sessionContext: AgentSessionContext,
+) {
+  const workspacePath =
+    sessionContext.workspacePathOverride?.trim() || project?.workspacePath;
+
+  return workspacePath?.replace(/\\/g, "/") ?? "No workspace selected";
+}
+
 export function ChatShell() {
   const [snapshot, setSnapshot] = useState<WorkbenchSnapshot>({
     activeSessionId: null,
@@ -549,7 +559,9 @@ export function ChatShell() {
             <div>
               <p className="panel-kicker">Chat</p>
               <h2>{activeSession?.title ?? "No session"}</h2>
-              <p className="session-subtitle">{formatWorkspacePath(activeProject)}</p>
+              <p className="session-subtitle">
+                {formatActiveWorkspacePath(activeProject, sessionContext)}
+              </p>
             </div>
           </div>
 

--- a/src/components/chat/chat-shell.tsx
+++ b/src/components/chat/chat-shell.tsx
@@ -154,6 +154,7 @@ export function ChatShell() {
   const sessionContext: AgentSessionContext =
     activeSession?.sessionContext ?? {};
   const pendingDraft = sessionContext.pendingDraft;
+  const pendingWorkspaceSwitch = sessionContext.pendingWorkspaceSwitch;
 
   useEffect(() => {
     void loadWorkbench();
@@ -374,6 +375,20 @@ export function ChatShell() {
     await submitTask(task, displayTask);
   }
 
+  async function handleWorkspaceSwitchDecision(decision: "approve" | "cancel") {
+    if (!pendingWorkspaceSwitch) {
+      return;
+    }
+
+    const task =
+      decision === "approve"
+        ? `CONFIRM_WORKSPACE_SWITCH ${pendingWorkspaceSwitch.id}`
+        : `CANCEL_WORKSPACE_SWITCH ${pendingWorkspaceSwitch.id}`;
+    const displayTask = decision === "approve" ? "YES" : "NO";
+
+    await submitTask(task, displayTask);
+  }
+
   async function createProjectFromPrompt() {
     if (isLoading) {
       return;
@@ -561,6 +576,7 @@ export function ChatShell() {
               <h2>{activeSession?.title ?? "No session"}</h2>
               <p className="session-subtitle">
                 {formatActiveWorkspacePath(activeProject, sessionContext)}
+                {sessionContext.readOnly ? " | read-only" : ""}
               </p>
             </div>
           </div>
@@ -625,6 +641,34 @@ export function ChatShell() {
                   type="button"
                   disabled={isLoading}
                   onClick={() => void handleDraftDecision("cancel")}
+                >
+                  NO
+                </button>
+              </div>
+            </div>
+          ) : null}
+
+          {pendingWorkspaceSwitch ? (
+            <div className="draft-decision-panel">
+              <p className="draft-decision-copy">
+                Switch this session to{" "}
+                <strong>{pendingWorkspaceSwitch.workspacePath}</strong>
+                {pendingWorkspaceSwitch.readOnly ? " in read-only mode" : ""}?
+              </p>
+              <div className="draft-decision-row">
+                <button
+                  className="decision-button yes"
+                  type="button"
+                  disabled={isLoading}
+                  onClick={() => void handleWorkspaceSwitchDecision("approve")}
+                >
+                  YES
+                </button>
+                <button
+                  className="decision-button no"
+                  type="button"
+                  disabled={isLoading}
+                  onClick={() => void handleWorkspaceSwitchDecision("cancel")}
                 >
                   NO
                 </button>

--- a/src/lib/agent/agent-response.ts
+++ b/src/lib/agent/agent-response.ts
@@ -4,9 +4,14 @@ import type {
   AgentStreamEvent,
   ChatMessage,
 } from "@/types/agent";
+import type { ToolRun } from "@/lib/agent/tool-run-types";
 
 export type RunAgentOptions = {
   onEvent?: (event: AgentStreamEvent) => void | Promise<void>;
+  onToolRun?: (toolRun: ToolRun) => void | Promise<void>;
+  projectId?: string;
+  sessionId?: string;
+  workspaceRoot?: string;
 };
 
 export function createStep(id: string, title: string, detail: string): AgentStep {

--- a/src/lib/agent/conversation-context.ts
+++ b/src/lib/agent/conversation-context.ts
@@ -47,6 +47,7 @@ export function normalizeSessionContext(
     lastToolInput: sessionContext.lastToolInput?.trim() || null,
     lastToolName: sessionContext.lastToolName?.trim() || null,
     projectId: sessionContext.projectId?.trim() || null,
+    readOnly: sessionContext.readOnly === true,
     sessionId: sessionContext.sessionId?.trim() || null,
     workspacePathOverride: sessionContext.workspacePathOverride?.trim() || null,
     pendingDraft: sessionContext.pendingDraft
@@ -62,6 +63,7 @@ export function normalizeSessionContext(
           ...sessionContext.pendingWorkspaceSwitch,
           id: sessionContext.pendingWorkspaceSwitch.id.trim(),
           originalTask: sessionContext.pendingWorkspaceSwitch.originalTask.trim(),
+          readOnly: sessionContext.pendingWorkspaceSwitch.readOnly === true,
           workspacePath:
             sessionContext.pendingWorkspaceSwitch.workspacePath.trim(),
         }

--- a/src/lib/agent/conversation-context.ts
+++ b/src/lib/agent/conversation-context.ts
@@ -48,12 +48,22 @@ export function normalizeSessionContext(
     lastToolName: sessionContext.lastToolName?.trim() || null,
     projectId: sessionContext.projectId?.trim() || null,
     sessionId: sessionContext.sessionId?.trim() || null,
+    workspacePathOverride: sessionContext.workspacePathOverride?.trim() || null,
     pendingDraft: sessionContext.pendingDraft
       ? {
           ...sessionContext.pendingDraft,
           content: sessionContext.pendingDraft.content,
           id: sessionContext.pendingDraft.id.trim(),
           path: sessionContext.pendingDraft.path.trim(),
+        }
+      : null,
+    pendingWorkspaceSwitch: sessionContext.pendingWorkspaceSwitch
+      ? {
+          ...sessionContext.pendingWorkspaceSwitch,
+          id: sessionContext.pendingWorkspaceSwitch.id.trim(),
+          originalTask: sessionContext.pendingWorkspaceSwitch.originalTask.trim(),
+          workspacePath:
+            sessionContext.pendingWorkspaceSwitch.workspacePath.trim(),
         }
       : null,
   };

--- a/src/lib/agent/conversation-context.ts
+++ b/src/lib/agent/conversation-context.ts
@@ -46,6 +46,8 @@ export function normalizeSessionContext(
     lastReadFilePath: sessionContext.lastReadFilePath?.trim() || null,
     lastToolInput: sessionContext.lastToolInput?.trim() || null,
     lastToolName: sessionContext.lastToolName?.trim() || null,
+    projectId: sessionContext.projectId?.trim() || null,
+    sessionId: sessionContext.sessionId?.trim() || null,
     pendingDraft: sessionContext.pendingDraft
       ? {
           ...sessionContext.pendingDraft,

--- a/src/lib/agent/draft-lifecycle.ts
+++ b/src/lib/agent/draft-lifecycle.ts
@@ -1,9 +1,6 @@
 import type { AgentResponse } from "@/types/agent";
-import {
-  applyPendingWriteDraft,
-  clearPendingWriteDraft,
-  getPendingWriteDraft,
-} from "@/lib/tools/pending-write";
+import type { WriteFileDraft } from "@/lib/tools/types";
+import { applyPendingWriteDraft } from "@/lib/tools/pending-write";
 import {
   createMessage,
   createStep,
@@ -91,6 +88,7 @@ export function isAmbiguousDraftConfirmation(task: string) {
 
 export async function handleWriteApproval(
   task: string,
+  pendingDraft: WriteFileDraft | null,
 ): Promise<AgentResponse | null> {
   const command = parseWriteCommand(task);
 
@@ -131,8 +129,6 @@ export async function handleWriteApproval(
   }
 
   if (command.type === "approve") {
-    const pendingDraft = getPendingWriteDraft();
-
     if (!pendingDraft) {
       return {
         message: createMessage("There is no pending write draft to approve."),
@@ -189,7 +185,7 @@ export async function handleWriteApproval(
       };
     }
 
-    const appliedDraft = await applyPendingWriteDraft();
+    const appliedDraft = await applyPendingWriteDraft(pendingDraft);
 
     return {
       message: createMessage(
@@ -224,8 +220,6 @@ export async function handleWriteApproval(
       ],
     };
   }
-
-  const pendingDraft = getPendingWriteDraft();
 
   if (!pendingDraft) {
     return {
@@ -282,8 +276,6 @@ export async function handleWriteApproval(
       ],
     };
   }
-
-  clearPendingWriteDraft();
 
   return {
     message: createMessage(

--- a/src/lib/agent/run-agent.ts
+++ b/src/lib/agent/run-agent.ts
@@ -396,16 +396,49 @@ function buildMessagesWithToolRuns(baseMessages: LlmMessage[], toolRuns: ToolRun
 
 function isFileModificationRequest(task: string) {
   return (
-    /(modify|edit|update|change|append|replace|rewrite|revise)/i.test(task) ||
+    /(modify|edit|update|change|append|replace|rewrite|revise|write|create|overwrite|delete|remove)/i.test(task) ||
     /(修改|编辑|更新|改动|追加|替换|重写|删除|增加)/u.test(task)
   );
 }
+function createReadOnlyBlockedResponse(
+  sessionContext: AgentSessionContext,
+): AgentResponse {
+  return {
+    message: createMessage(
+      [
+        "Current session is read-only, so I cannot modify files.",
+        "",
+        "Exit read-only mode before asking me to write, replace, create, or delete files.",
+      ].join("\n"),
+    ),
+    sessionContext,
+    steps: [
+      createStep(
+        "perceive",
+        "Perceive",
+        "Read a request that would modify files while this session is read-only.",
+      ),
+      createStep(
+        "think",
+        "Think",
+        "Read-only mode disables write_file and replace_text for this session.",
+      ),
+      createStep(
+        "act",
+        "Act",
+        "Stop before modifying files and tell the user how to continue.",
+      ),
+    ],
+  };
+}
+
 async function think(
   context: AgentContext,
   perception: PerceptionResult,
   toolRuns: ToolRun[],
 ): Promise<ThoughtResult> {
-  const availableTools = listTools();
+  const readOnly = context.sessionContext.readOnly === true;
+  const availableTools = listTools({ readOnly });
   const roundNumber = toolRuns.length + 1;
   const remainingToolCalls = getRemainingToolCalls(toolRuns);
   const plan = buildThoughtPlan(toolRuns, remainingToolCalls);
@@ -505,6 +538,9 @@ async function think(
             "You may request at most one tool in each reply.",
             `The full user request may use at most ${MAX_TOOL_CALLS} tool calls total.`,
             buildPlannerBudgetInstruction(toolRuns, remainingToolCalls),
+            readOnly
+              ? "This session is read-only. Do not modify files. The write_file and replace_text tools are unavailable."
+              : "",
             "If the user wants to modify an existing file, first use read_file to get the current content.",
             "If the user asks for one exact text replacement inside an existing file, prefer replace_text after read_file.",
             "If the user asks to create, edit, or overwrite a file and the change is broader than one exact replacement, prefer the write_file tool.",
@@ -554,6 +590,7 @@ async function think(
       ],
       toolRuns,
     ),
+    context.toolNames,
   );
 
   const normalizedToolInput = plannerReply.toolCall
@@ -603,6 +640,28 @@ async function thinkAfterReadForModification(
   roundNumber: number,
   issuePlanText?: string | null,
 ): Promise<ThoughtResult> {
+  if (context.sessionContext.readOnly) {
+    return {
+      assistantMessage: null,
+      directAnswer:
+        "Current session is read-only, so I cannot prepare a file modification draft. Exit read-only mode before asking me to modify files.",
+      nextAction: "Return a read-only mode refusal instead of preparing a write draft.",
+      plan: [
+        "Review the existing file content.",
+        "Notice that this session is read-only.",
+        "Stop before preparing a write draft.",
+      ],
+      toolCallId: null,
+      toolName: null,
+      toolInput: null,
+      step: createStep(
+        `think-${roundNumber}`,
+        "Think",
+        "This session is read-only, so file modification tools are disabled.",
+      ),
+    };
+  }
+
   const reply = await callModelForToolDecision(
     context.model,
     buildMessagesWithToolRuns(
@@ -910,12 +969,25 @@ export async function runAgent(
     ...normalizedSessionContext,
     pendingDraft: normalizedSessionContext.pendingDraft ?? null,
     projectId: options.projectId ?? normalizedSessionContext.projectId ?? null,
+    readOnly: normalizedSessionContext.readOnly === true,
     sessionId: options.sessionId ?? normalizedSessionContext.sessionId ?? null,
   };
   const exactWriteCommand = parseWriteCommand(task);
   const draftLifecycleAction = exactWriteCommand
     ? null
     : parseDraftLifecycleAction(task);
+
+  if (
+    effectiveSessionContext.readOnly &&
+    exactWriteCommand?.type === "approve" &&
+    effectiveSessionContext.pendingDraft
+  ) {
+    return finishWithLogging(
+      createReadOnlyBlockedResponse(effectiveSessionContext),
+      true,
+      0,
+    );
+  }
 
   const writeApprovalResult = await handleWriteApproval(
     task,
@@ -1015,6 +1087,14 @@ export async function runAgent(
     draftLifecycleAction === "approve" &&
     effectiveSessionContext.pendingDraft
   ) {
+    if (effectiveSessionContext.readOnly) {
+      return finishWithLogging(
+        createReadOnlyBlockedResponse(effectiveSessionContext),
+        true,
+        0,
+      );
+    }
+
     const approvalResult = await handleWriteApproval(
       `${APPROVE_WRITE_COMMAND} ${effectiveSessionContext.pendingDraft.id}`,
       effectiveSessionContext.pendingDraft,
@@ -1103,6 +1183,17 @@ export async function runAgent(
     );
   }
 
+  if (
+    effectiveSessionContext.readOnly &&
+    isFileModificationRequest(task)
+  ) {
+    return finishWithLogging(
+      createReadOnlyBlockedResponse(effectiveSessionContext),
+      true,
+      0,
+    );
+  }
+
   if (!process.env.DEEPSEEK_API_KEY) {
     throw new Error("Missing DEEPSEEK_API_KEY.");
   }
@@ -1119,7 +1210,9 @@ export async function runAgent(
     model,
     recentConversation: preparedConversationContext.recentConversation,
     sessionContext: preparedConversationContext.sessionContext,
-    toolNames: listTools().map((tool) => tool.name),
+    toolNames: listTools({
+      readOnly: preparedConversationContext.sessionContext.readOnly === true,
+    }).map((tool) => tool.name),
   };
 
   const steps: AgentStep[] = [];
@@ -1235,6 +1328,9 @@ export async function runAgent(
                 },
               },
             ],
+          },
+          {
+            readOnly: context.sessionContext.readOnly === true,
           },
         );
 

--- a/src/lib/agent/run-agent.ts
+++ b/src/lib/agent/run-agent.ts
@@ -5,14 +5,11 @@ import type {
   ChatMessage,
 } from "@/types/agent";
 import { listTools } from "@/lib/tools/tool-registry";
+import { withWorkspaceRoot } from "@/lib/tools/workspace-path";
 import type {
   ToolCallArgs,
   ToolExecutionInput,
 } from "@/lib/tools/types";
-import {
-  getPendingWriteDraft,
-  savePendingWriteDraft,
-} from "@/lib/tools/pending-write";
 import { createLogger } from "@/lib/logger";
 import {
   formatConversationForModel,
@@ -886,6 +883,7 @@ export async function runAgent(
   options: RunAgentOptions = {},
 ): Promise<AgentResponse> {
   const onEvent = options.onEvent;
+  const onToolRun = options.onToolRun;
   const finish = async (response: AgentResponse, includeSteps: boolean) =>
     finishAgentRun(response, onEvent, includeSteps);
   const logger = createLogger(requestId);
@@ -908,17 +906,21 @@ export async function runAgent(
   };
 
   const normalizedSessionContext = normalizeSessionContext(sessionContext);
-  const backendPendingDraft = getPendingWriteDraft();
   const effectiveSessionContext: AgentSessionContext = {
     ...normalizedSessionContext,
-    pendingDraft: backendPendingDraft ?? null,
+    pendingDraft: normalizedSessionContext.pendingDraft ?? null,
+    projectId: options.projectId ?? normalizedSessionContext.projectId ?? null,
+    sessionId: options.sessionId ?? normalizedSessionContext.sessionId ?? null,
   };
   const exactWriteCommand = parseWriteCommand(task);
   const draftLifecycleAction = exactWriteCommand
     ? null
     : parseDraftLifecycleAction(task);
 
-  const writeApprovalResult = await handleWriteApproval(task);
+  const writeApprovalResult = await handleWriteApproval(
+    task,
+    effectiveSessionContext.pendingDraft ?? null,
+  );
   if (writeApprovalResult) {
     return finishWithLogging(
       {
@@ -933,7 +935,7 @@ export async function runAgent(
     );
   }
 
-  if (draftLifecycleAction && !backendPendingDraft) {
+  if (draftLifecycleAction && !effectiveSessionContext.pendingDraft) {
     return finishWithLogging(
       {
         message: createMessage(
@@ -968,7 +970,7 @@ export async function runAgent(
   }
 
   if (
-    backendPendingDraft &&
+    effectiveSessionContext.pendingDraft &&
     !draftLifecycleAction &&
     isAmbiguousDraftConfirmation(task)
   ) {
@@ -977,11 +979,11 @@ export async function runAgent(
         message: createMessage(
           [
             "I found a pending draft, but your confirmation word was too vague.",
-            `Draft id: ${backendPendingDraft.id}`,
-            `Target path: ${backendPendingDraft.path}`,
-            `If you want to write it, say: ${APPROVE_WRITE_COMMAND} ${backendPendingDraft.id}`,
+            `Draft id: ${effectiveSessionContext.pendingDraft.id}`,
+            `Target path: ${effectiveSessionContext.pendingDraft.path}`,
+            `If you want to write it, say: ${APPROVE_WRITE_COMMAND} ${effectiveSessionContext.pendingDraft.id}`,
             `Or simply reply: approve / 批准`,
-            `If you want to discard it, say: ${CANCEL_WRITE_COMMAND} ${backendPendingDraft.id}`,
+            `If you want to discard it, say: ${CANCEL_WRITE_COMMAND} ${effectiveSessionContext.pendingDraft.id}`,
             `Or simply reply: cancel / 取消`,
           ].join("\n"),
         ),
@@ -1011,10 +1013,11 @@ export async function runAgent(
 
   if (
     draftLifecycleAction === "approve" &&
-    backendPendingDraft
+    effectiveSessionContext.pendingDraft
   ) {
     const approvalResult = await handleWriteApproval(
-      `${APPROVE_WRITE_COMMAND} ${backendPendingDraft.id}`,
+      `${APPROVE_WRITE_COMMAND} ${effectiveSessionContext.pendingDraft.id}`,
+      effectiveSessionContext.pendingDraft,
     );
 
     if (!approvalResult) {
@@ -1036,10 +1039,11 @@ export async function runAgent(
 
   if (
     draftLifecycleAction === "cancel" &&
-    backendPendingDraft
+    effectiveSessionContext.pendingDraft
   ) {
     const cancelResult = await handleWriteApproval(
-      `${CANCEL_WRITE_COMMAND} ${backendPendingDraft.id}`,
+      `${CANCEL_WRITE_COMMAND} ${effectiveSessionContext.pendingDraft.id}`,
+      effectiveSessionContext.pendingDraft,
     );
 
     if (!cancelResult) {
@@ -1209,26 +1213,34 @@ export async function runAgent(
 
     let toolRun: ToolRun;
     try {
-      toolRun = await runToolCall(
-        thought.toolName,
-        thought.toolInput,
-        thought.toolCallId ?? createSyntheticToolCallId(),
-        thought.assistantMessage ?? {
-          role: "assistant",
-          content: "",
-          reasoning_content: "",
-          tool_calls: [
-            {
-              id: thought.toolCallId ?? createSyntheticToolCallId(),
-              type: "function",
-              function: {
-                name: thought.toolName,
-                arguments: formatToolExecutionInput(thought.toolInput),
+      const toolName = thought.toolName;
+      const toolInput = thought.toolInput;
+      const toolCallId = thought.toolCallId ?? createSyntheticToolCallId();
+      const runCurrentTool = () =>
+        runToolCall(
+          toolName,
+          toolInput,
+          toolCallId,
+          thought.assistantMessage ?? {
+            role: "assistant",
+            content: "",
+            reasoning_content: "",
+            tool_calls: [
+              {
+                id: toolCallId,
+                type: "function",
+                function: {
+                  name: toolName,
+                  arguments: formatToolExecutionInput(toolInput),
+                },
               },
-            },
-          ],
-        },
-      );
+            ],
+          },
+        );
+
+      toolRun = options.workspaceRoot
+        ? await withWorkspaceRoot(options.workspaceRoot, runCurrentTool)
+        : await runCurrentTool();
       logger.info("tool call completed", {
         toolName: thought.toolName,
         succeeded: toolRun.result.ok,
@@ -1242,6 +1254,7 @@ export async function runAgent(
     }
 
     toolRuns.push(toolRun);
+    await onToolRun?.(toolRun);
 
     await pushStep(
       createStep(
@@ -1253,10 +1266,6 @@ export async function runAgent(
 
     const immediateOutcome = getImmediateToolOutcome(perception.goal, toolRuns);
     if (immediateOutcome) {
-      if (toolRun.result.draft) {
-        savePendingWriteDraft(toolRun.result.draft);
-      }
-
       await replaceLastStep(
         createStep(`act-${roundNumber}`, "Act", immediateOutcome.actDetail),
       );

--- a/src/lib/agent/session-state.ts
+++ b/src/lib/agent/session-state.ts
@@ -6,6 +6,7 @@ export function formatSessionContextForModel(
   sessionContext: AgentSessionContext,
 ) {
   const lines = [
+    `Read-only mode: ${sessionContext.readOnly ? "on" : "off"}`,
     `Last tool name: ${sessionContext.lastToolName ?? "none"}`,
     `Last tool input: ${sessionContext.lastToolInput ?? "none"}`,
     `Last listed directory: ${sessionContext.lastListedDirectoryPath ?? "none"}`,

--- a/src/lib/agent/session-state.ts
+++ b/src/lib/agent/session-state.ts
@@ -21,6 +21,15 @@ export function formatSessionContextForModel(
     lines.push("Pending draft id: none");
   }
 
+  if (sessionContext.pendingWorkspaceSwitch) {
+    lines.push(`Pending workspace switch id: ${sessionContext.pendingWorkspaceSwitch.id}`);
+    lines.push(
+      `Pending workspace switch path: ${sessionContext.pendingWorkspaceSwitch.workspacePath}`,
+    );
+  } else {
+    lines.push("Pending workspace switch id: none");
+  }
+
   lines.push(
     "Reference rules: if the user says 'that draft', prefer the pending draft. If the user says 'that file', prefer the pending draft path first, then the last read file. If the user says 'continue the last step', prefer continuing the pending draft flow; otherwise use the last tool context.",
   );

--- a/src/lib/agent/tool-run-types.ts
+++ b/src/lib/agent/tool-run-types.ts
@@ -9,10 +9,13 @@ export type DirectToolPlan = {
 
 export type ToolRun = {
   assistantMessage: LlmMessage;
+  durationMs?: number;
+  finishedAt?: number;
   input: ToolExecutionInput;
   inputText: string;
   name: string;
   result: ToolResult;
+  startedAt?: number;
   toolCallId: string;
 };
 

--- a/src/lib/agent/tool-runner.ts
+++ b/src/lib/agent/tool-runner.ts
@@ -15,15 +15,20 @@ export async function runToolCall(
     throw new Error(`Tool "${toolName}" is not registered.`);
   }
 
+  const startedAt = Date.now();
   const result = await tool.execute(toolInput);
+  const finishedAt = Date.now();
   const inputText = formatToolExecutionInput(toolInput);
 
   return {
     assistantMessage,
+    durationMs: finishedAt - startedAt,
+    finishedAt,
     name: toolName,
     input: toolInput,
     inputText,
     result,
+    startedAt,
     toolCallId,
   };
 }

--- a/src/lib/agent/tool-runner.ts
+++ b/src/lib/agent/tool-runner.ts
@@ -1,4 +1,4 @@
-import { getTool } from "@/lib/tools/tool-registry";
+import { getTool, isReadOnlyBlockedTool } from "@/lib/tools/tool-registry";
 import type { ToolExecutionInput } from "@/lib/tools/types";
 import { formatToolExecutionInput } from "@/lib/agent/tool-args";
 import type { LlmMessage } from "@/lib/agent/model-client";
@@ -9,6 +9,7 @@ export async function runToolCall(
   toolInput: ToolExecutionInput,
   toolCallId: string,
   assistantMessage: LlmMessage,
+  options: { readOnly?: boolean } = {},
 ): Promise<ToolRun> {
   const tool = getTool(toolName);
   if (!tool) {
@@ -16,9 +17,33 @@ export async function runToolCall(
   }
 
   const startedAt = Date.now();
+  const inputText = formatToolExecutionInput(toolInput);
+
+  if (options.readOnly && isReadOnlyBlockedTool(toolName)) {
+    const finishedAt = Date.now();
+
+    return {
+      assistantMessage,
+      durationMs: finishedAt - startedAt,
+      finishedAt,
+      name: toolName,
+      input: toolInput,
+      inputText,
+      result: {
+        ok: false,
+        content: [
+          "Current session is read-only, so file modifications are disabled.",
+          `Blocked tool: ${toolName}`,
+          "Exit read-only mode before modifying files.",
+        ].join("\n"),
+      },
+      startedAt,
+      toolCallId,
+    };
+  }
+
   const result = await tool.execute(toolInput);
   const finishedAt = Date.now();
-  const inputText = formatToolExecutionInput(toolInput);
 
   return {
     assistantMessage,

--- a/src/lib/agent/workspace-switch.ts
+++ b/src/lib/agent/workspace-switch.ts
@@ -1,0 +1,325 @@
+import path from "node:path";
+import type { AgentSessionContext, AgentStep } from "@/types/agent";
+import { normalizeWorkspacePath } from "@/lib/workspace/validation";
+
+const CONFIRM_WORKSPACE_SWITCH_COMMAND = "CONFIRM_WORKSPACE_SWITCH";
+const CANCEL_WORKSPACE_SWITCH_COMMAND = "CANCEL_WORKSPACE_SWITCH";
+
+type WorkspaceSwitchResult =
+  | {
+      handled: false;
+    }
+  | {
+      handled: true;
+      message: string;
+      sessionContext: AgentSessionContext;
+      steps: AgentStep[];
+    };
+
+function buildWorkspaceSwitchSteps(detail: string): AgentStep[] {
+  return [
+    {
+      id: "perceive",
+      title: "Perceive",
+      detail: "Detected a workspace switch request in the chat.",
+      status: "done",
+    },
+    {
+      id: "think",
+      title: "Think",
+      detail,
+      status: "done",
+    },
+    {
+      id: "act",
+      title: "Act",
+      detail: "Reply in chat and update only this session state when confirmed.",
+      status: "done",
+    },
+  ];
+}
+
+function createSwitchId() {
+  return "ws_" + Math.random().toString(36).slice(2, 10);
+}
+
+function isConfirmTask(task: string, expectedId?: string) {
+  const cleanTask = task.trim();
+
+  if (
+    expectedId &&
+    cleanTask.toUpperCase() ===
+      `${CONFIRM_WORKSPACE_SWITCH_COMMAND} ${expectedId}`.toUpperCase()
+  ) {
+    return true;
+  }
+
+  return (
+    /^(yes|y|ok)$/i.test(cleanTask) ||
+    /^(\u786e\u8ba4|\u662f|\u53ef\u4ee5|\u597d|\u5207\u6362|\u5207\u5230\u8fd9\u4e2a\u9879\u76ee)$/.test(
+      cleanTask,
+    )
+  );
+}
+
+function isCancelTask(task: string, expectedId?: string) {
+  const cleanTask = task.trim();
+
+  if (
+    expectedId &&
+    cleanTask.toUpperCase() ===
+      `${CANCEL_WORKSPACE_SWITCH_COMMAND} ${expectedId}`.toUpperCase()
+  ) {
+    return true;
+  }
+
+  return (
+    /^(no|n|cancel)$/i.test(cleanTask) ||
+    /^(\u53d6\u6d88|\u4e0d\u8981|\u4e0d\u5207|\u7b97\u4e86)$/.test(cleanTask)
+  );
+}
+
+function stripWrappingQuotes(rawPath: string) {
+  return rawPath.replace(/^["'`]+|["'`]+$/g, "").trim();
+}
+
+function cleanExtractedPath(rawPath: string) {
+  let cleanPath = stripWrappingQuotes(rawPath.trim());
+
+  cleanPath = cleanPath.replace(/[;,!?].*$/g, "").trim();
+
+  const trailingPhrases = [
+    "look",
+    "inspect",
+    "check",
+    "\u770b\u770b",
+    "\u770b\u4e00\u4e0b",
+    "\u770b\u4e0b",
+    "\u68c0\u67e5\u4e00\u4e0b",
+    "\u68c0\u67e5\u4e0b",
+    "\u8fd9\u4e2a\u9879\u76ee",
+    "\u8fd9\u4e2a\u76ee\u5f55",
+    "\u8fd9\u4e2a\u6587\u4ef6\u5939",
+    "\u5207\u5230\u8fd9\u4e2a\u9879\u76ee",
+    "\u5207\u8fc7\u53bb",
+  ];
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+
+    for (const phrase of trailingPhrases) {
+      if (cleanPath.toLowerCase().endsWith(phrase.toLowerCase())) {
+        cleanPath = cleanPath.slice(0, -phrase.length).trim();
+        changed = true;
+      }
+    }
+  }
+
+  return stripWrappingQuotes(cleanPath);
+}
+
+export function extractWorkspaceSwitchPath(task: string) {
+  const quotedPathMatch = task.match(/["']([^"']*[A-Za-z]:[\\/][^"']+)["']/);
+  if (quotedPathMatch?.[1]) {
+    return cleanExtractedPath(quotedPathMatch[1]);
+  }
+
+  const windowsPathMatch = task.match(/[A-Za-z]:[\\/][^\r\n]+/);
+  if (windowsPathMatch?.[0]) {
+    return cleanExtractedPath(windowsPathMatch[0]);
+  }
+
+  const unixPathMatch = task.match(/(?:^|\s)(\/[^\r\n]+)/);
+  if (unixPathMatch?.[1]) {
+    return cleanExtractedPath(unixPathMatch[1]);
+  }
+
+  return null;
+}
+
+export function getEffectiveWorkspacePath(
+  sessionContext: AgentSessionContext,
+  projectWorkspacePath: string,
+) {
+  return sessionContext.workspacePathOverride?.trim() || projectWorkspacePath;
+}
+
+export function handleWorkspaceSwitchTask(input: {
+  projectId: string;
+  projectWorkspacePath: string;
+  sessionContext: AgentSessionContext;
+  sessionId: string;
+  task: string;
+}): WorkspaceSwitchResult {
+  const { projectId, projectWorkspacePath, sessionId, task } = input;
+  const sessionContext: AgentSessionContext = {
+    ...input.sessionContext,
+    projectId,
+    sessionId,
+  };
+  const pendingSwitch = sessionContext.pendingWorkspaceSwitch ?? null;
+
+  if (pendingSwitch && isCancelTask(task, pendingSwitch.id)) {
+    return {
+      handled: true,
+      message: [
+        "Workspace switch cancelled.",
+        "",
+        `Current workspace: ${getEffectiveWorkspacePath(
+          sessionContext,
+          projectWorkspacePath,
+        )}`,
+      ].join("\n"),
+      sessionContext: {
+        ...sessionContext,
+        pendingWorkspaceSwitch: null,
+      },
+      steps: buildWorkspaceSwitchSteps("The user cancelled the pending workspace switch."),
+    };
+  }
+
+  if (pendingSwitch && isConfirmTask(task, pendingSwitch.id)) {
+    if (sessionContext.pendingDraft) {
+      return {
+        handled: true,
+        message: [
+          "I cannot switch workspace yet because this session has a pending write draft.",
+          "",
+          `Draft path: ${sessionContext.pendingDraft.path}`,
+          "",
+          "Approve the draft with YES, or discard it with NO. Then confirm the workspace switch again.",
+        ].join("\n"),
+        sessionContext,
+        steps: buildWorkspaceSwitchSteps(
+          "Blocked workspace switch because a pending write draft still exists.",
+        ),
+      };
+    }
+
+    let workspacePath: string;
+
+    try {
+      workspacePath = normalizeWorkspacePath(pendingSwitch.workspacePath);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Workspace path validation failed.";
+
+      return {
+        handled: true,
+        message: [
+          "The pending workspace path is no longer valid, so I did not switch.",
+          "",
+          message,
+          "",
+          "Send a real local folder path again to retry.",
+        ].join("\n"),
+        sessionContext: {
+          ...sessionContext,
+          pendingWorkspaceSwitch: null,
+        },
+        steps: buildWorkspaceSwitchSteps("The pending workspace path failed validation."),
+      };
+    }
+
+    return {
+      handled: true,
+      message: [
+        "Switched this session to the new workspace.",
+        "",
+        `New workspace: ${workspacePath}`,
+        "",
+        "I also cleared the old file and directory hints for this session, so later tool calls stay tied to the new workspace.",
+      ].join("\n"),
+      sessionContext: {
+        ...sessionContext,
+        lastListedDirectoryPath: null,
+        lastReadFilePath: null,
+        lastToolInput: null,
+        lastToolName: null,
+        pendingWorkspaceSwitch: null,
+        workspacePathOverride: workspacePath,
+      },
+      steps: buildWorkspaceSwitchSteps("The workspace switch was confirmed and applied."),
+    };
+  }
+
+  const requestedPath = extractWorkspaceSwitchPath(task);
+  if (!requestedPath) {
+    return { handled: false };
+  }
+
+  let workspacePath: string;
+
+  try {
+    workspacePath = normalizeWorkspacePath(requestedPath);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Workspace path validation failed.";
+
+    return {
+      handled: true,
+      message: [
+        "I did not switch workspace because the path failed validation.",
+        "",
+        message,
+        "",
+        "Send a specific local project folder that already exists.",
+      ].join("\n"),
+      sessionContext,
+      steps: buildWorkspaceSwitchSteps("The requested workspace path failed validation."),
+    };
+  }
+
+  if (sessionContext.pendingDraft) {
+    return {
+      handled: true,
+      message: [
+        "I cannot switch workspace because this session has a pending write draft.",
+        "",
+        `Draft path: ${sessionContext.pendingDraft.path}`,
+        "",
+        "Approve the draft with YES, or discard it with NO. Then send the workspace switch request again.",
+      ].join("\n"),
+      sessionContext,
+      steps: buildWorkspaceSwitchSteps(
+        "Blocked workspace switch before confirmation because a pending write draft exists.",
+      ),
+    };
+  }
+
+  const switchId = createSwitchId();
+  const nextContext: AgentSessionContext = {
+    ...sessionContext,
+    pendingWorkspaceSwitch: {
+      id: switchId,
+      originalTask: task,
+      requestedAt: Date.now(),
+      workspacePath,
+    },
+  };
+
+  return {
+    handled: true,
+    message: [
+      "I can switch this session to that workspace, but need your confirmation first.",
+      "",
+      `Target workspace: ${workspacePath}`,
+      `Current workspace: ${getEffectiveWorkspacePath(sessionContext, projectWorkspacePath)}`,
+      "",
+      "After confirmation:",
+      "- Only this session changes; other sessions in the project stay unchanged.",
+      "- Agent tools will be limited to the target workspace.",
+      "- Old file and directory hints will be cleared to avoid mixing paths.",
+      "",
+      `To switch, reply: ${CONFIRM_WORKSPACE_SWITCH_COMMAND} ${switchId}`,
+      `To cancel, reply: ${CANCEL_WORKSPACE_SWITCH_COMMAND} ${switchId}`,
+      "",
+      "You can also reply with yes/confirm or no/cancel.",
+    ].join("\n"),
+    sessionContext: nextContext,
+    steps: buildWorkspaceSwitchSteps(
+      `Validated target folder ${path.basename(workspacePath) || workspacePath} and requested confirmation.`,
+    ),
+  };
+}

--- a/src/lib/agent/workspace-switch.ts
+++ b/src/lib/agent/workspace-switch.ts
@@ -79,6 +79,25 @@ function isCancelTask(task: string, expectedId?: string) {
   );
 }
 
+function isReadOnlyRequested(task: string) {
+  return (
+    /read[\s-]*only|readonly/i.test(task) ||
+    /(\u53ea\u8bfb|\u53ea\u770b\u4e0d\u6539)/.test(task)
+  );
+}
+
+function isReadOnlyExitTask(task: string) {
+  const cleanTask = task.trim();
+
+  return (
+    /^(exit|disable|turn off|leave)\s+read[\s-]*only(?:\s+mode)?$/i.test(cleanTask) ||
+    /^normal\s+mode$/i.test(cleanTask) ||
+    /^(\u9000\u51fa\u53ea\u8bfb|\u5173\u95ed\u53ea\u8bfb|\u5207\u56de\u6b63\u5e38\u6a21\u5f0f|\u6b63\u5e38\u6a21\u5f0f)$/.test(
+      cleanTask,
+    )
+  );
+}
+
 function stripWrappingQuotes(rawPath: string) {
   return rawPath.replace(/^["'`]+|["'`]+$/g, "").trim();
 }
@@ -86,6 +105,13 @@ function stripWrappingQuotes(rawPath: string) {
 function cleanExtractedPath(rawPath: string) {
   let cleanPath = stripWrappingQuotes(rawPath.trim());
 
+  cleanPath = cleanPath
+    .replace(/\s*(?:\((?:read[\s-]*only|readonly)\)|read[\s-]*only|readonly)\s*$/i, "")
+    .replace(
+      /\s*(?:\uFF08\u53ea\u8bfb\uFF09|\(\u53ea\u8bfb\)|\u53ea\u8bfb\u6a21\u5f0f|\u53ea\u8bfb)\s*$/,
+      "",
+    )
+    .trim();
   cleanPath = cleanPath.replace(/[;,!?].*$/g, "").trim();
 
   const trailingPhrases = [
@@ -160,6 +186,28 @@ export function handleWorkspaceSwitchTask(input: {
   };
   const pendingSwitch = sessionContext.pendingWorkspaceSwitch ?? null;
 
+  if (isReadOnlyExitTask(task)) {
+    return {
+      handled: true,
+      message: [
+        "Read-only mode is now off for this session.",
+        "",
+        `Current workspace: ${getEffectiveWorkspacePath(
+          sessionContext,
+          projectWorkspacePath,
+        )}`,
+        "",
+        "Write tools are available again.",
+      ].join("\n"),
+      sessionContext: {
+        ...sessionContext,
+        pendingWorkspaceSwitch: null,
+        readOnly: false,
+      },
+      steps: buildWorkspaceSwitchSteps("The user turned read-only mode off."),
+    };
+  }
+
   if (pendingSwitch && isCancelTask(task, pendingSwitch.id)) {
     return {
       handled: true,
@@ -228,6 +276,7 @@ export function handleWorkspaceSwitchTask(input: {
         "Switched this session to the new workspace.",
         "",
         `New workspace: ${workspacePath}`,
+        `Mode: ${pendingSwitch.readOnly ? "read-only" : sessionContext.readOnly ? "read-only" : "normal"}`,
         "",
         "I also cleared the old file and directory hints for this session, so later tool calls stay tied to the new workspace.",
       ].join("\n"),
@@ -238,6 +287,7 @@ export function handleWorkspaceSwitchTask(input: {
         lastToolInput: null,
         lastToolName: null,
         pendingWorkspaceSwitch: null,
+        readOnly: pendingSwitch.readOnly ? true : sessionContext.readOnly === true,
         workspacePathOverride: workspacePath,
       },
       steps: buildWorkspaceSwitchSteps("The workspace switch was confirmed and applied."),
@@ -289,11 +339,13 @@ export function handleWorkspaceSwitchTask(input: {
   }
 
   const switchId = createSwitchId();
+  const readOnly = isReadOnlyRequested(task);
   const nextContext: AgentSessionContext = {
     ...sessionContext,
     pendingWorkspaceSwitch: {
       id: switchId,
       originalTask: task,
+      readOnly,
       requestedAt: Date.now(),
       workspacePath,
     },
@@ -306,10 +358,14 @@ export function handleWorkspaceSwitchTask(input: {
       "",
       `Target workspace: ${workspacePath}`,
       `Current workspace: ${getEffectiveWorkspacePath(sessionContext, projectWorkspacePath)}`,
+      `Mode after switch: ${readOnly ? "read-only" : sessionContext.readOnly ? "read-only" : "normal"}`,
       "",
       "After confirmation:",
       "- Only this session changes; other sessions in the project stay unchanged.",
       "- Agent tools will be limited to the target workspace.",
+      readOnly
+        ? "- File modification tools will be disabled for this session."
+        : "- Current read-only setting will stay unchanged.",
       "- Old file and directory hints will be cleared to avoid mixing paths.",
       "",
       `To switch, reply: ${CONFIRM_WORKSPACE_SWITCH_COMMAND} ${switchId}`,

--- a/src/lib/db/connection.ts
+++ b/src/lib/db/connection.ts
@@ -1,0 +1,97 @@
+import Database from "better-sqlite3";
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+
+let db: Database.Database | null = null;
+
+function getDatabasePath() {
+  return path.resolve(process.cwd(), "data", "thrush.db");
+}
+
+function applySchema(database: Database.Database) {
+  database.exec(`
+    PRAGMA foreign_keys = ON;
+
+    CREATE TABLE IF NOT EXISTS projects (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      workspace_path TEXT NOT NULL UNIQUE,
+      workspace_path_confirmed_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS sessions (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'active',
+      context_json TEXT NOT NULL DEFAULT '{}',
+      steps_json TEXT NOT NULL DEFAULT '[]',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE IF NOT EXISTS messages (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      role TEXT NOT NULL CHECK (role IN ('user', 'assistant')),
+      content TEXT NOT NULL,
+      reasoning_content TEXT,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE IF NOT EXISTS tool_runs (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      request_id TEXT NOT NULL,
+      tool_call_id TEXT NOT NULL,
+      tool_name TEXT NOT NULL,
+      input_json TEXT NOT NULL,
+      input_text TEXT NOT NULL,
+      ok INTEGER NOT NULL,
+      result_content TEXT NOT NULL,
+      draft_json TEXT,
+      started_at INTEGER NOT NULL,
+      finished_at INTEGER NOT NULL,
+      duration_ms INTEGER NOT NULL,
+      FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE IF NOT EXISTS checkpoints (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      request_id TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      label TEXT,
+      data_json TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_sessions_project_updated
+      ON sessions(project_id, updated_at);
+    CREATE INDEX IF NOT EXISTS idx_messages_session_created
+      ON messages(session_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_tool_runs_session_finished
+      ON tool_runs(session_id, finished_at);
+    CREATE INDEX IF NOT EXISTS idx_checkpoints_session_created
+      ON checkpoints(session_id, created_at);
+  `);
+}
+
+export function getDb() {
+  if (db) {
+    return db;
+  }
+
+  const databasePath = getDatabasePath();
+  mkdirSync(path.dirname(databasePath), { recursive: true });
+
+  db = new Database(databasePath);
+  applySchema(db);
+
+  return db;
+}

--- a/src/lib/db/store.ts
+++ b/src/lib/db/store.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, statSync } from "node:fs";
+import { mkdirSync } from "node:fs";
 import path from "node:path";
 import type {
   AgentSessionContext,
@@ -15,6 +15,7 @@ import type {
 import type { ToolRun } from "@/lib/agent/tool-run-types";
 import { getDb } from "@/lib/db/connection";
 import { getDefaultWorkspaceRoot } from "@/lib/tools/workspace-path";
+import { normalizeWorkspacePath } from "@/lib/workspace/validation";
 
 type ProjectRow = {
   created_at: number;
@@ -66,38 +67,6 @@ function parseJson<T>(raw: string, fallback: T): T {
   } catch {
     return fallback;
   }
-}
-
-function normalizeWorkspacePath(workspacePath: string) {
-  const resolvedPath = path.resolve(workspacePath.trim());
-
-  if (!path.isAbsolute(resolvedPath)) {
-    throw new Error("Workspace path must be absolute.");
-  }
-
-  if (!existsSync(resolvedPath)) {
-    throw new Error(`Workspace path does not exist: ${resolvedPath}`);
-  }
-
-  if (!statSync(resolvedPath).isDirectory()) {
-    throw new Error(`Workspace path is not a folder: ${resolvedPath}`);
-  }
-
-  const parsed = path.parse(resolvedPath);
-  const normalized = path.normalize(resolvedPath);
-  const blockedRoots = [
-    parsed.root,
-    path.resolve(parsed.root, "Windows"),
-    path.resolve(parsed.root, "Program Files"),
-    path.resolve(parsed.root, "Program Files (x86)"),
-    path.resolve(parsed.root, "Users"),
-  ].map((blockedPath) => path.normalize(blockedPath).toLowerCase());
-
-  if (blockedRoots.includes(normalized.toLowerCase())) {
-    throw new Error("Workspace path is too broad. Choose a specific project folder.");
-  }
-
-  return normalized;
 }
 
 function mapSessionSummary(row: SessionRow): SessionSummary {

--- a/src/lib/db/store.ts
+++ b/src/lib/db/store.ts
@@ -1,0 +1,443 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, statSync } from "node:fs";
+import path from "node:path";
+import type {
+  AgentSessionContext,
+  AgentStep,
+  ChatMessage,
+} from "@/types/agent";
+import type {
+  ProjectSummary,
+  SessionDetail,
+  SessionSummary,
+  WorkbenchSnapshot,
+} from "@/types/workbench";
+import type { ToolRun } from "@/lib/agent/tool-run-types";
+import { getDb } from "@/lib/db/connection";
+import { getDefaultWorkspaceRoot } from "@/lib/tools/workspace-path";
+
+type ProjectRow = {
+  created_at: number;
+  id: string;
+  name: string;
+  updated_at: number;
+  workspace_path: string;
+  workspace_path_confirmed_at: number | null;
+};
+
+type SessionRow = {
+  context_json: string;
+  created_at: number;
+  id: string;
+  project_id: string;
+  steps_json: string;
+  title: string;
+  updated_at: number;
+};
+
+type MessageRow = {
+  content: string;
+  created_at: number;
+  id: string;
+  reasoning_content: string | null;
+  role: "user" | "assistant";
+};
+
+const starterSteps: AgentStep[] = [
+  {
+    id: "waiting",
+    title: "Waiting for a task",
+    detail: "The agent is idle until you send a message.",
+    status: "idle",
+  },
+];
+
+function now() {
+  return Date.now();
+}
+
+function createId(prefix: string) {
+  return `${prefix}_${randomUUID()}`;
+}
+
+function parseJson<T>(raw: string, fallback: T): T {
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function normalizeWorkspacePath(workspacePath: string) {
+  const resolvedPath = path.resolve(workspacePath.trim());
+
+  if (!path.isAbsolute(resolvedPath)) {
+    throw new Error("Workspace path must be absolute.");
+  }
+
+  if (!existsSync(resolvedPath)) {
+    throw new Error(`Workspace path does not exist: ${resolvedPath}`);
+  }
+
+  if (!statSync(resolvedPath).isDirectory()) {
+    throw new Error(`Workspace path is not a folder: ${resolvedPath}`);
+  }
+
+  const parsed = path.parse(resolvedPath);
+  const normalized = path.normalize(resolvedPath);
+  const blockedRoots = [
+    parsed.root,
+    path.resolve(parsed.root, "Windows"),
+    path.resolve(parsed.root, "Program Files"),
+    path.resolve(parsed.root, "Program Files (x86)"),
+    path.resolve(parsed.root, "Users"),
+  ].map((blockedPath) => path.normalize(blockedPath).toLowerCase());
+
+  if (blockedRoots.includes(normalized.toLowerCase())) {
+    throw new Error("Workspace path is too broad. Choose a specific project folder.");
+  }
+
+  return normalized;
+}
+
+function mapSessionSummary(row: SessionRow): SessionSummary {
+  return {
+    createdAt: row.created_at,
+    id: row.id,
+    projectId: row.project_id,
+    title: row.title,
+    updatedAt: row.updated_at,
+  };
+}
+
+function mapProjectSummary(row: ProjectRow, sessions: SessionSummary[]): ProjectSummary {
+  return {
+    createdAt: row.created_at,
+    id: row.id,
+    name: row.name,
+    sessions,
+    updatedAt: row.updated_at,
+    workspacePath: row.workspace_path,
+    workspacePathConfirmedAt: row.workspace_path_confirmed_at,
+  };
+}
+
+function listSessionRowsForProject(projectId: string) {
+  return getDb()
+    .prepare(
+      `SELECT id, project_id, title, context_json, steps_json, created_at, updated_at
+       FROM sessions
+       WHERE project_id = ?
+       ORDER BY updated_at DESC`,
+    )
+    .all(projectId) as SessionRow[];
+}
+
+export function createProject(input: {
+  confirmWorkspace: boolean;
+  name: string;
+  workspacePath: string;
+}) {
+  if (!input.confirmWorkspace) {
+    throw new Error("Workspace path must be confirmed before it is saved.");
+  }
+
+  const db = getDb();
+  const timestamp = now();
+  const projectId = createId("proj");
+  const workspacePath = normalizeWorkspacePath(input.workspacePath);
+  const name = input.name.trim() || path.basename(workspacePath) || "Untitled project";
+
+  db.prepare(
+    `INSERT INTO projects
+      (id, name, workspace_path, workspace_path_confirmed_at, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(projectId, name, workspacePath, timestamp, timestamp, timestamp);
+
+  createSession(projectId, "New session");
+
+  return getProject(projectId);
+}
+
+export function createSession(projectId: string, title = "New session") {
+  const db = getDb();
+  const project = getProject(projectId);
+
+  if (!project) {
+    throw new Error("Project was not found.");
+  }
+
+  const timestamp = now();
+  const sessionId = createId("sess");
+  const context: AgentSessionContext = {
+    projectId,
+    sessionId,
+  };
+
+  db.prepare(
+    `INSERT INTO sessions
+      (id, project_id, title, context_json, steps_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    sessionId,
+    projectId,
+    title,
+    JSON.stringify(context),
+    JSON.stringify(starterSteps),
+    timestamp,
+    timestamp,
+  );
+
+  return getSession(sessionId);
+}
+
+export function appendMessage(input: {
+  content: string;
+  reasoningContent?: string | null;
+  role: "user" | "assistant";
+  sessionId: string;
+}) {
+  const db = getDb();
+  const timestamp = now();
+  const id = createId(input.role === "user" ? "user" : "assistant");
+
+  db.prepare(
+    `INSERT INTO messages
+      (id, session_id, role, content, reasoning_content, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    input.sessionId,
+    input.role,
+    input.content,
+    input.reasoningContent ?? null,
+    timestamp,
+  );
+
+  touchSession(input.sessionId, timestamp);
+
+  return {
+    id,
+    role: input.role,
+    content: input.content,
+    ...(input.reasoningContent ? { reasoning_content: input.reasoningContent } : {}),
+  } satisfies ChatMessage;
+}
+
+export function updateSessionState(
+  sessionId: string,
+  sessionContext: AgentSessionContext,
+  steps: AgentStep[],
+) {
+  const timestamp = now();
+  getDb()
+    .prepare(
+      `UPDATE sessions
+       SET context_json = ?, steps_json = ?, updated_at = ?
+       WHERE id = ?`,
+    )
+    .run(
+      JSON.stringify({
+        ...sessionContext,
+        sessionId,
+      }),
+      JSON.stringify(steps),
+      timestamp,
+      sessionId,
+    );
+}
+
+function touchSession(sessionId: string, timestamp = now()) {
+  getDb()
+    .prepare("UPDATE sessions SET updated_at = ? WHERE id = ?")
+    .run(timestamp, sessionId);
+}
+
+export function getProject(projectId: string) {
+  const row = getDb()
+    .prepare(
+      `SELECT id, name, workspace_path, workspace_path_confirmed_at, created_at, updated_at
+       FROM projects
+       WHERE id = ?`,
+    )
+    .get(projectId) as ProjectRow | undefined;
+
+  if (!row) {
+    return null;
+  }
+
+  return mapProjectSummary(row, listSessionRowsForProject(projectId).map(mapSessionSummary));
+}
+
+export function getSession(sessionId: string): SessionDetail | null {
+  const row = getDb()
+    .prepare(
+      `SELECT id, project_id, title, context_json, steps_json, created_at, updated_at
+       FROM sessions
+       WHERE id = ?`,
+    )
+    .get(sessionId) as SessionRow | undefined;
+
+  if (!row) {
+    return null;
+  }
+
+  const messageRows = getDb()
+    .prepare(
+      `SELECT id, role, content, reasoning_content, created_at
+       FROM messages
+       WHERE session_id = ?
+       ORDER BY created_at ASC`,
+    )
+    .all(sessionId) as MessageRow[];
+
+  const sessionContext = parseJson<AgentSessionContext>(row.context_json, {});
+
+  return {
+    ...mapSessionSummary(row),
+    messages: messageRows.map((message) => ({
+      id: message.id,
+      role: message.role,
+      content: message.content,
+      ...(message.reasoning_content
+        ? { reasoning_content: message.reasoning_content }
+        : {}),
+    })),
+    sessionContext: {
+      ...sessionContext,
+      projectId: row.project_id,
+      sessionId: row.id,
+    },
+    steps: parseJson<AgentStep[]>(row.steps_json, starterSteps),
+  };
+}
+
+export function getSessionProject(sessionId: string) {
+  const session = getSession(sessionId);
+
+  if (!session) {
+    return null;
+  }
+
+  const project = getProject(session.projectId);
+
+  if (!project) {
+    return null;
+  }
+
+  return {
+    project,
+    session,
+  };
+}
+
+export function listProjects() {
+  const projectRows = getDb()
+    .prepare(
+      `SELECT id, name, workspace_path, workspace_path_confirmed_at, created_at, updated_at
+       FROM projects
+       ORDER BY updated_at DESC`,
+    )
+    .all() as ProjectRow[];
+
+  return projectRows.map((project) =>
+    mapProjectSummary(
+      project,
+      listSessionRowsForProject(project.id).map(mapSessionSummary),
+    ),
+  );
+}
+
+export function ensureWorkbench(): WorkbenchSnapshot {
+  let projects = listProjects();
+
+  if (projects.length === 0) {
+    mkdirSync(getDefaultWorkspaceRoot(), { recursive: true });
+    createProject({
+      confirmWorkspace: true,
+      name: "Demo workspace",
+      workspacePath: getDefaultWorkspaceRoot(),
+    });
+    projects = listProjects();
+  }
+
+  const activeSessionId =
+    projects.flatMap((project) => project.sessions).sort((left, right) =>
+      right.updatedAt - left.updatedAt,
+    )[0]?.id ?? null;
+
+  return {
+    activeSessionId,
+    projects,
+  };
+}
+
+export function recordToolRun(input: {
+  requestId: string;
+  sessionId: string;
+  toolRun: ToolRun;
+}) {
+  const finishedAt = now();
+  const startedAt = input.toolRun.startedAt ?? finishedAt;
+
+  getDb()
+    .prepare(
+      `INSERT INTO tool_runs
+        (id, session_id, request_id, tool_call_id, tool_name, input_json,
+         input_text, ok, result_content, draft_json, started_at, finished_at, duration_ms)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      createId("tool"),
+      input.sessionId,
+      input.requestId,
+      input.toolRun.toolCallId,
+      input.toolRun.name,
+      JSON.stringify(input.toolRun.input),
+      input.toolRun.inputText,
+      input.toolRun.result.ok ? 1 : 0,
+      input.toolRun.result.content,
+      input.toolRun.result.draft
+        ? JSON.stringify(input.toolRun.result.draft)
+        : null,
+      startedAt,
+      input.toolRun.finishedAt ?? finishedAt,
+      input.toolRun.durationMs ?? Math.max(finishedAt - startedAt, 0),
+    );
+}
+
+export function createCheckpoint(input: {
+  data: unknown;
+  kind: string;
+  label?: string | null;
+  requestId: string;
+  sessionId: string;
+}) {
+  getDb()
+    .prepare(
+      `INSERT INTO checkpoints
+        (id, session_id, request_id, kind, label, data_json, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      createId("chk"),
+      input.sessionId,
+      input.requestId,
+      input.kind,
+      input.label ?? null,
+      JSON.stringify(input.data),
+      now(),
+    );
+}
+
+export function listToolRuns(sessionId: string) {
+  return getDb()
+    .prepare(
+      `SELECT id, session_id, request_id, tool_call_id, tool_name, input_text,
+        ok, result_content, started_at, finished_at, duration_ms
+       FROM tool_runs
+       WHERE session_id = ?
+       ORDER BY finished_at DESC`,
+    )
+    .all(sessionId);
+}

--- a/src/lib/tools/pending-write.ts
+++ b/src/lib/tools/pending-write.ts
@@ -3,32 +3,15 @@ import path from "node:path";
 import type { WriteFileDraft } from "@/lib/tools/types";
 import { resolveWorkspacePath } from "@/lib/tools/workspace-path";
 
-let pendingDraft: WriteFileDraft | null = null;
-
-export function savePendingWriteDraft(draft: WriteFileDraft) {
-  pendingDraft = draft;
-}
-
-export function getPendingWriteDraft() {
-  return pendingDraft;
-}
-
-export function clearPendingWriteDraft() {
-  pendingDraft = null;
-}
-
-export async function applyPendingWriteDraft() {
-  if (!pendingDraft) {
+export async function applyPendingWriteDraft(draft: WriteFileDraft | null) {
+  if (!draft) {
     return null;
   }
 
-  const draft = pendingDraft;
   const targetPath = resolveWorkspacePath(draft.path);
 
   await mkdir(path.dirname(targetPath), { recursive: true });
   await writeFile(targetPath, draft.content, "utf8");
-
-  pendingDraft = null;
 
   return draft;
 }

--- a/src/lib/tools/tool-registry.ts
+++ b/src/lib/tools/tool-registry.ts
@@ -10,6 +10,8 @@ import { webSearchTool } from "@/lib/tools/web-search";
 import { writeFileTool } from "@/lib/tools/write-file";
 import type { AgentTool } from "@/lib/tools/types";
 
+const readOnlyBlockedToolNames = new Set(["write_file", "replace_text"]);
+
 const tools: AgentTool[] = [
   clickPageTool,
   gitInspectTool,
@@ -23,14 +25,22 @@ const tools: AgentTool[] = [
   writeFileTool,
 ];
 
+export function isReadOnlyBlockedTool(toolName: string) {
+  return readOnlyBlockedToolNames.has(toolName);
+}
+
 export function getTool(name: string) {
   return tools.find((tool) => tool.name === name);
 }
 
-export function listTools() {
-  return tools.map((tool) => ({
-    name: tool.name,
-    description: tool.description,
-    inputSchema: tool.inputSchema,
-  }));
+export function listTools(options: { readOnly?: boolean } = {}) {
+  return tools
+    .filter((tool) =>
+      options.readOnly ? !isReadOnlyBlockedTool(tool.name) : true,
+    )
+    .map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+    }));
 }

--- a/src/lib/tools/workspace-path.ts
+++ b/src/lib/tools/workspace-path.ts
@@ -1,7 +1,13 @@
-import { existsSync, statSync } from "node:fs";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { existsSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 
 const DEFAULT_WORKSPACE_ROOT = path.resolve(process.cwd(), "data", "workspace");
+const workspaceRootStorage = new AsyncLocalStorage<string>();
+
+export function getDefaultWorkspaceRoot() {
+  return DEFAULT_WORKSPACE_ROOT;
+}
 
 function resolveConfiguredWorkspaceRoot() {
   const configuredRoot = process.env.AGENT_WORKSPACE_ROOT?.trim();
@@ -34,9 +40,19 @@ function validateWorkspaceRoot(workspaceRoot: string) {
 }
 
 export function getWorkspaceRoot() {
-  const workspaceRoot = resolveConfiguredWorkspaceRoot();
+  const workspaceRoot = workspaceRootStorage.getStore() ?? resolveConfiguredWorkspaceRoot();
   validateWorkspaceRoot(workspaceRoot);
   return workspaceRoot;
+}
+
+export async function withWorkspaceRoot<T>(
+  workspaceRoot: string,
+  callback: () => Promise<T>,
+) {
+  const resolvedWorkspaceRoot = path.resolve(workspaceRoot);
+  validateWorkspaceRoot(resolvedWorkspaceRoot);
+
+  return workspaceRootStorage.run(resolvedWorkspaceRoot, callback);
 }
 
 export function resolveWorkspacePath(input = ".") {
@@ -50,6 +66,19 @@ export function resolveWorkspacePath(input = ".") {
     path.isAbsolute(relativePath)
   ) {
     throw new Error("The requested path is outside the configured workspace.");
+  }
+
+  if (existsSync(targetPath)) {
+    const realWorkspaceRoot = realpathSync.native(workspaceRoot);
+    const realTargetPath = realpathSync.native(targetPath);
+    const realRelativePath = path.relative(realWorkspaceRoot, realTargetPath);
+
+    if (
+      realRelativePath.startsWith("..") ||
+      path.isAbsolute(realRelativePath)
+    ) {
+      throw new Error("The requested path resolves outside the configured workspace.");
+    }
   }
 
   return targetPath;

--- a/src/lib/workspace/validation.ts
+++ b/src/lib/workspace/validation.ts
@@ -1,0 +1,34 @@
+import { existsSync, statSync } from "node:fs";
+import path from "node:path";
+
+export function normalizeWorkspacePath(workspacePath: string) {
+  const resolvedPath = path.resolve(workspacePath.trim());
+
+  if (!path.isAbsolute(resolvedPath)) {
+    throw new Error("Workspace path must be absolute.");
+  }
+
+  if (!existsSync(resolvedPath)) {
+    throw new Error(`Workspace path does not exist: ${resolvedPath}`);
+  }
+
+  if (!statSync(resolvedPath).isDirectory()) {
+    throw new Error(`Workspace path is not a folder: ${resolvedPath}`);
+  }
+
+  const parsed = path.parse(resolvedPath);
+  const normalized = path.normalize(resolvedPath);
+  const blockedRoots = [
+    parsed.root,
+    path.resolve(parsed.root, "Windows"),
+    path.resolve(parsed.root, "Program Files"),
+    path.resolve(parsed.root, "Program Files (x86)"),
+    path.resolve(parsed.root, "Users"),
+  ].map((blockedPath) => path.normalize(blockedPath).toLowerCase());
+
+  if (blockedRoots.includes(normalized.toLowerCase())) {
+    throw new Error("Workspace path is too broad. Choose a specific project folder.");
+  }
+
+  return normalized;
+}

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -14,6 +14,13 @@ export type PendingDraftSnapshot = {
   path: string;
 };
 
+export type PendingWorkspaceSwitch = {
+  id: string;
+  originalTask: string;
+  requestedAt: number;
+  workspacePath: string;
+};
+
 export type AgentSessionContext = {
   conversationSummary?: string | null;
   lastListedDirectoryPath?: string | null;
@@ -21,8 +28,10 @@ export type AgentSessionContext = {
   lastToolInput?: string | null;
   lastToolName?: string | null;
   pendingDraft?: PendingDraftSnapshot | null;
+  pendingWorkspaceSwitch?: PendingWorkspaceSwitch | null;
   projectId?: string | null;
   sessionId?: string | null;
+  workspacePathOverride?: string | null;
 };
 
 export type StepStatus = "idle" | "running" | "done";

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -21,6 +21,8 @@ export type AgentSessionContext = {
   lastToolInput?: string | null;
   lastToolName?: string | null;
   pendingDraft?: PendingDraftSnapshot | null;
+  projectId?: string | null;
+  sessionId?: string | null;
 };
 
 export type StepStatus = "idle" | "running" | "done";
@@ -34,7 +36,9 @@ export type AgentStep = {
 
 export type AgentRequest = {
   messages?: ChatMessage[];
+  projectId?: string;
   sessionContext?: AgentSessionContext;
+  sessionId?: string;
   stream?: boolean;
   task: string;
 };

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -17,6 +17,7 @@ export type PendingDraftSnapshot = {
 export type PendingWorkspaceSwitch = {
   id: string;
   originalTask: string;
+  readOnly?: boolean;
   requestedAt: number;
   workspacePath: string;
 };
@@ -30,6 +31,7 @@ export type AgentSessionContext = {
   pendingDraft?: PendingDraftSnapshot | null;
   pendingWorkspaceSwitch?: PendingWorkspaceSwitch | null;
   projectId?: string | null;
+  readOnly?: boolean | null;
   sessionId?: string | null;
   workspacePathOverride?: string | null;
 };

--- a/src/types/workbench.ts
+++ b/src/types/workbench.ts
@@ -1,0 +1,34 @@
+import type {
+  AgentSessionContext,
+  AgentStep,
+  ChatMessage,
+} from "@/types/agent";
+
+export type ProjectSummary = {
+  createdAt: number;
+  id: string;
+  name: string;
+  sessions: SessionSummary[];
+  updatedAt: number;
+  workspacePath: string;
+  workspacePathConfirmedAt: number | null;
+};
+
+export type SessionSummary = {
+  createdAt: number;
+  id: string;
+  projectId: string;
+  title: string;
+  updatedAt: number;
+};
+
+export type SessionDetail = SessionSummary & {
+  messages: ChatMessage[];
+  sessionContext: AgentSessionContext;
+  steps: AgentStep[];
+};
+
+export type WorkbenchSnapshot = {
+  activeSessionId: string | null;
+  projects: ProjectSummary[];
+};


### PR DESCRIPTION
Summary:
- Add SQLite-backed project/session workbench with session-scoped context and tool run history.
- Add session workspace switching with explicit confirmation and pending draft protection.
- Add read-only session mode, write-tool filtering, execution-time write blocking, and YES/NO confirmation buttons.

Verification:
- npx tsc --noEmit
- npm run lint
- npm test
- npm run build
- API smoke: workspace switch confirmation and pending draft blocking
- API smoke: read-only switch, write rejection, exit read-only
- Playwright smoke: workbench loads and workspace switch YES/NO buttons render