### PR TITLE
refactor: split agent loop and abstract model client

### DIFF
--- a/src/lib/agent/agent-thinking.ts
+++ b/src/lib/agent/agent-thinking.ts
@@ -1,0 +1,762 @@
+import type {
+  AgentSessionContext,
+  AgentStep,
+  ChatMessage,
+} from "@/types/agent";
+import { listTools } from "@/lib/tools/tool-registry";
+import type {
+  ToolCallArgs,
+  ToolExecutionInput,
+} from "@/lib/tools/types";
+import {
+  formatConversationForModel,
+  formatConversationSummaryForModel,
+} from "@/lib/agent/conversation-context";
+import {
+  callModelForText,
+  callModelForToolDecision,
+  type LlmMessage,
+} from "@/lib/agent/model-client";
+import { createStep } from "@/lib/agent/agent-response";
+import {
+  getNumberArg,
+  getStringArg,
+  getStringArrayArg,
+  formatToolExecutionInput,
+  formatToolRunsForModel,
+} from "@/lib/agent/tool-args";
+import {
+  MAX_TOOL_CALLS,
+  type ToolRun,
+} from "@/lib/agent/tool-run-types";
+import { formatSessionContextForModel } from "@/lib/agent/session-state";
+import {
+  deriveIssueInvestigationToolCallFromToolRun,
+  deriveIssuePlanToolCallFromToolRun,
+  getLatestIssuePlanText,
+  isIssueDrivenReadForDraft,
+} from "@/lib/agent/issue-flow";
+import {
+  deriveDirectToolPlan,
+  deriveFocusedWebSearchQuery,
+  deriveWebSearchQueryFromTask,
+} from "@/lib/agent/direct-tool-plans";
+
+export type AgentContext = {
+  cleanTask: string;
+  recentConversation: ChatMessage[];
+  sessionContext: AgentSessionContext;
+  model: string;
+  toolNames: string[];
+};
+
+export type PerceptionResult = {
+  goal: string;
+  taskSize: string;
+  step: AgentStep;
+};
+
+export type ThoughtResult = {
+  assistantMessage: LlmMessage | null;
+  directAnswer: string | null;
+  nextAction: string;
+  plan: string[];
+  step: AgentStep;
+  toolCallId: string | null;
+  toolInput: ToolExecutionInput | null;
+  toolName: string | null;
+};
+
+type ThinkStrategyContext = {
+  context: AgentContext;
+  perception: PerceptionResult;
+  roundNumber: number;
+  toolRuns: ToolRun[];
+};
+
+type ThinkStrategy = {
+  match: (toolRuns: ToolRun[], goal: string) => boolean;
+  think: (context: ThinkStrategyContext) => Promise<ThoughtResult> | ThoughtResult;
+};
+
+function getRemainingToolCalls(toolRuns: ToolRun[]) {
+  return Math.max(MAX_TOOL_CALLS - toolRuns.length, 0);
+}
+
+function buildThoughtPlan(toolRuns: ToolRun[], remainingToolCalls: number) {
+  if (toolRuns.length === 0) {
+    return [
+      "Understand what the user wants.",
+      "Ask the model whether it needs a tool.",
+      "Use the safest next action.",
+    ];
+  }
+
+  if (remainingToolCalls > 0) {
+    return [
+      "Review the latest tool result.",
+      "Decide whether another tool is still needed.",
+      "Answer now if the task is already complete.",
+    ];
+  }
+
+  return [
+    "Review the completed tool results.",
+    "Stop using tools.",
+    "Turn the results into a final answer.",
+  ];
+}
+
+function buildPlannerBudgetInstruction(toolRuns: ToolRun[], remainingToolCalls: number) {
+  if (toolRuns.length === 0) {
+    return "Choose between requesting the first tool or giving a direct answer.";
+  }
+
+  if (remainingToolCalls > 0) {
+    return `You have already seen ${toolRuns.length} tool result${toolRuns.length === 1 ? "" : "s"}. Choose one next tool call or give the final answer now.`;
+  }
+
+  return "No more tool calls remain. Give the final answer now.";
+}
+
+function normalizeToolInput(toolName: string, rawInput: ToolCallArgs, task: string) {
+  if (toolName === "list_files") {
+    return {
+      path: getStringArg(rawInput, "path") || ".",
+    };
+  }
+
+  if (toolName === "read_file") {
+    const path = getStringArg(rawInput, "path");
+
+    if (!path) {
+      return null;
+    }
+
+    const startLine = getNumberArg(rawInput, "start_line");
+    const maxLines = getNumberArg(rawInput, "max_lines");
+
+    return {
+      path,
+      ...(startLine === null ? {} : { start_line: startLine }),
+      ...(maxLines === null ? {} : { max_lines: maxLines }),
+    };
+  }
+
+  if (toolName === "read_page") {
+    const url = getStringArg(rawInput, "url");
+    const maxChars = getNumberArg(rawInput, "max_chars");
+
+    if (!url) {
+      return null;
+    }
+
+    return maxChars === null ? { url } : { url, max_chars: maxChars };
+  }
+
+  if (toolName === "click_page") {
+    const url = getStringArg(rawInput, "url");
+    const selector = getStringArg(rawInput, "selector");
+    const maxChars = getNumberArg(rawInput, "max_chars");
+
+    if (!url || !selector) {
+      return null;
+    }
+
+    return maxChars === null
+      ? { url, selector }
+      : { url, selector, max_chars: maxChars };
+  }
+
+  if (toolName === "write_file") {
+    const path = getStringArg(rawInput, "path");
+    const contentValue = rawInput.content;
+    const content = typeof contentValue === "string" ? contentValue : null;
+
+    if (!path || content === null) {
+      return null;
+    }
+
+    return {
+      path,
+      content,
+    };
+  }
+
+  if (toolName === "replace_text") {
+    const path = getStringArg(rawInput, "path");
+    const oldTextValue = rawInput.old_text;
+    const newTextValue = rawInput.new_text;
+    const oldText = typeof oldTextValue === "string" ? oldTextValue : null;
+    const newText = typeof newTextValue === "string" ? newTextValue : null;
+
+    if (!path || oldText === null || oldText.length === 0 || newText === null) {
+      return null;
+    }
+
+    return {
+      path,
+      old_text: oldText,
+      new_text: newText,
+    };
+  }
+
+  if (toolName === "search_text") {
+    const query = getStringArg(rawInput, "query");
+    const path = getStringArg(rawInput, "path");
+
+    if (!query) {
+      return null;
+    }
+
+    return path ? { query, path } : { query };
+  }
+
+  if (toolName === "safe_command") {
+    const command = getStringArg(rawInput, "command").toLowerCase();
+    const args = getStringArrayArg(rawInput, "args");
+
+    if (!command || args.length === 0) {
+      return null;
+    }
+
+    return {
+      command,
+      args,
+    };
+  }
+
+  if (toolName === "web_search") {
+    const query = getStringArg(rawInput, "query");
+
+    return {
+      query: deriveFocusedWebSearchQuery(deriveWebSearchQueryFromTask(query || task)),
+    };
+  }
+
+  return rawInput;
+}
+
+export function perceive(context: AgentContext): PerceptionResult {
+  const wordCount = context.cleanTask.split(/\s+/).filter(Boolean).length;
+  const taskSize = wordCount <= 6 ? "small" : "multi-part";
+
+  return {
+    goal: context.cleanTask,
+    taskSize,
+    step: createStep(
+      "perceive",
+      "Perceive",
+      `Read the task, clean the input, and identify the goal: "${context.cleanTask}". The task looks ${taskSize}. Recent conversation messages available: ${context.recentConversation.length}. Reference hints available: ${context.sessionContext.pendingDraft ? "pending draft" : "no pending draft"}.`,
+    ),
+  };
+}
+
+function buildMessagesWithToolRuns(baseMessages: LlmMessage[], toolRuns: ToolRun[]) {
+  const toolMessages = toolRuns.flatMap((toolRun) => [
+    toolRun.assistantMessage,
+    {
+      role: "tool" as const,
+      tool_call_id: toolRun.toolCallId,
+      content: toolRun.result.content,
+    },
+  ]);
+
+  return [...baseMessages, ...toolMessages];
+}
+
+export function isFileModificationRequest(task: string) {
+  return (
+    /(modify|edit|update|change|append|replace|rewrite|revise|write|create|overwrite|delete|remove)/i.test(task) ||
+    /(淇敼|缂栬緫|鏇存柊|鏀瑰姩|杩藉姞|鏇挎崲|閲嶅啓|鍒犻櫎|澧炲姞)/u.test(task)
+  );
+}
+
+export async function think(
+  context: AgentContext,
+  perception: PerceptionResult,
+  toolRuns: ToolRun[],
+): Promise<ThoughtResult> {
+  const readOnly = context.sessionContext.readOnly === true;
+  const availableTools = listTools({ readOnly });
+  const roundNumber = toolRuns.length + 1;
+  const remainingToolCalls = getRemainingToolCalls(toolRuns);
+  const plan = buildThoughtPlan(toolRuns, remainingToolCalls);
+
+  const toolList = availableTools
+    .map(
+      (tool) =>
+        `- ${tool.name}: ${tool.description} Input form: ${JSON.stringify(tool.inputSchema)}`,
+    )
+    .join("\n");
+
+  const directToolPlan =
+    toolRuns.length === 0 ? deriveDirectToolPlan(perception.goal) : null;
+
+  if (directToolPlan) {
+    return {
+      assistantMessage: null,
+      directAnswer: null,
+      nextAction: `Use ${directToolPlan.name} with input ${formatToolExecutionInput(directToolPlan.input)}.`,
+      plan,
+      toolCallId: directToolPlan.id,
+      toolName: directToolPlan.name,
+      toolInput: directToolPlan.input,
+      step: createStep(
+        `think-${roundNumber}`,
+        "Think",
+        `Plan round ${roundNumber}: ${plan.join(" ")} Available tools: ${availableTools.map((tool) => tool.name).join(", ")}. Next action: Use ${directToolPlan.name} with input ${formatToolExecutionInput(directToolPlan.input)}.`,
+      ),
+    };
+  }
+
+  const plannerReply = await callModelForToolDecision(
+    context.model,
+    buildMessagesWithToolRuns(
+      [
+        {
+          role: "system",
+          content: [
+            "You are the planning step for a stripped-down coding agent.",
+            "You may request at most one tool in each reply.",
+            `The full user request may use at most ${MAX_TOOL_CALLS} tool calls total.`,
+            buildPlannerBudgetInstruction(toolRuns, remainingToolCalls),
+            readOnly
+              ? "This session is read-only. Do not modify files. The write_file and replace_text tools are unavailable."
+              : "",
+            "If the user wants to modify an existing file, first use read_file to get the current content.",
+            "If the user asks for one exact text replacement inside an existing file, prefer replace_text after read_file.",
+            "If the user asks to create, edit, or overwrite a file and the change is broader than one exact replacement, prefer the write_file tool.",
+            "If the user asks to open a web page, inspect a URL, or read page content from a live site, prefer read_page.",
+            "If the user asks to click one simple link, button, or tab on a live page, prefer click_page.",
+            "If the user asks whether the current workspace is a Git repository, prefer git_inspect with action check_repo.",
+            "If the user asks for one specific issue detail, prefer git_inspect with action issue_detail and include the issue_number.",
+            'If the user asks you to turn an issue into an execution plan, prefer git_inspect with action issue_plan. Pass pasted issue text in issue_text, or pass issue_number when the user names one GitHub issue number.',
+            "If the user asks for the current repository issue list, prefer git_inspect with action issue_list.",
+            "If the user asks for current GitHub repository info, prefer git_inspect with action repo_info.",
+            "If the user asks for a PR draft suggestion, prefer git_inspect with action pr_draft.",
+            "If the user asks to export a patch, generate patch text, or produce a diff patch, prefer git_inspect with action patch_export. This is read-only and must not commit or push.",
+            "If the user asks for a task_submit draft or task submit text, prefer git_inspect with action task_submit. This is read-only and must not commit, push, or actually submit anything.",
+            "If the user asks for a commit message suggestion, prefer git_inspect with action commit_message.",
+            "If the user asks whether the workspace is connected to GitHub, or asks about remotes, GitHub remotes, gh CLI, or GitHub login readiness, prefer git_inspect with action github_env.",
+            "If the user asks for git status or repository status, prefer git_inspect with action status.",
+            "If the user asks for git diff or repository diff, prefer git_inspect with action diff.",
+            "If the user asks for a Git change summary, prefer git_inspect with action summary.",
+            "If the user explicitly asks to run a local command, prefer safe_command instead of inventing shell output.",
+            "If the user asks to build, compile, or verify whether the project still builds, prefer safe_command with npm run build.",
+            "If the user asks you to search the web, look something up online, or needs current public information, prefer web_search.",
+            "Available tools:",
+            toolList,
+            "If you need one tool, call exactly one tool using the provided function definitions.",
+            "Fill tool arguments as JSON that matches the tool's input form.",
+            "Do not use safe_command for network access, shell wrappers, or any command outside its allowlist.",
+            "If you do not need a tool, answer normally in plain text.",
+          ].join("\n"),
+        },
+        {
+          role: "user",
+          content: [
+            "Older conversation summary:",
+            formatConversationSummaryForModel(context.sessionContext),
+            "",
+            "Recent conversation:",
+            formatConversationForModel(context.recentConversation),
+            "",
+            "Session reference hints:",
+            formatSessionContextForModel(context.sessionContext),
+            "",
+            `Original task: ${perception.goal}`,
+            `Tool calls already used: ${toolRuns.length}`,
+            `Tool calls remaining: ${remainingToolCalls}`,
+          ].join("\n"),
+        },
+      ],
+      toolRuns,
+    ),
+    context.toolNames,
+  );
+
+  const normalizedToolInput = plannerReply.toolCall
+    ? normalizeToolInput(
+        plannerReply.toolCall.name,
+        plannerReply.toolCall.input,
+        perception.goal,
+      )
+    : null;
+  const plannedToolCall =
+    plannerReply.toolCall && normalizedToolInput
+      ? {
+          id: plannerReply.toolCall.id,
+          name: plannerReply.toolCall.name,
+          input: normalizedToolInput,
+        }
+      : null;
+  const chosenToolInput = plannedToolCall?.input ?? null;
+  const directAnswer = plannerReply.content;
+
+  const nextAction = plannedToolCall
+    ? `Use ${plannedToolCall.name} with input ${formatToolExecutionInput(chosenToolInput ?? plannedToolCall.input)}.`
+    : directAnswer
+      ? "Return the model's direct answer."
+      : "Fallback to a direct model answer because the tool decision was invalid.";
+
+  return {
+    assistantMessage: plannerReply.assistantMessage,
+    directAnswer,
+    nextAction,
+    plan,
+    toolCallId: plannedToolCall?.id ?? null,
+    toolName: plannedToolCall?.name ?? null,
+    toolInput: chosenToolInput,
+    step: createStep(
+      `think-${roundNumber}`,
+      "Think",
+      `Plan round ${roundNumber}: ${plan.join(" ")} Available tools: ${availableTools.map((tool) => tool.name).join(", ")}. Next action: ${nextAction}`,
+    ),
+  };
+}
+
+async function thinkAfterReadForModification(
+  context: AgentContext,
+  goal: string,
+  readToolRun: ToolRun,
+  roundNumber: number,
+  issuePlanText?: string | null,
+): Promise<ThoughtResult> {
+  if (context.sessionContext.readOnly) {
+    return {
+      assistantMessage: null,
+      directAnswer:
+        "Current session is read-only, so I cannot prepare a file modification draft. Exit read-only mode before asking me to modify files.",
+      nextAction: "Return a read-only mode refusal instead of preparing a write draft.",
+      plan: [
+        "Review the existing file content.",
+        "Notice that this session is read-only.",
+        "Stop before preparing a write draft.",
+      ],
+      toolCallId: null,
+      toolName: null,
+      toolInput: null,
+      step: createStep(
+        `think-${roundNumber}`,
+        "Think",
+        "This session is read-only, so file modification tools are disabled.",
+      ),
+    };
+  }
+
+  const reply = await callModelForToolDecision(
+    context.model,
+    buildMessagesWithToolRuns(
+      [
+        {
+          role: "system",
+          content: [
+            "You are the editing step for a stripped-down coding agent.",
+            "The user wants to modify an existing file.",
+            "You already have the current file content from read_file.",
+            "If one exact old snippet can be safely replaced with one new snippet, call the replace_text tool first.",
+            "If the change is broader than one exact replacement, call the write_file tool.",
+            "The write_file content argument must contain the full final file content, not a diff.",
+            issuePlanText
+              ? "This read_file step came from an issue execution plan. If the likely fix is clear enough from the issue plan plus the current file content, prepare the smallest safe draft now."
+              : "Work only from the explicit user edit request and the current file content.",
+            "If the change request is too ambiguous to apply safely, ask the user one short clarifying question in plain text.",
+          ].join("\n"),
+        },
+        {
+          role: "user",
+          content: [
+            "Older conversation summary:",
+            formatConversationSummaryForModel(context.sessionContext),
+            "",
+            "Recent conversation:",
+            formatConversationForModel(context.recentConversation),
+            "",
+            "Session reference hints:",
+            formatSessionContextForModel(context.sessionContext),
+            "",
+            `Original task: ${goal}`,
+            `Target file path: ${readToolRun.inputText}`,
+            issuePlanText ? "" : null,
+            issuePlanText ? "Issue execution plan:" : null,
+            issuePlanText ?? null,
+          ].join("\n"),
+        },
+      ],
+      [readToolRun],
+    ),
+    ["replace_text", "write_file"],
+  );
+
+  const normalizedToolInput = reply.toolCall
+    ? normalizeToolInput(reply.toolCall.name, reply.toolCall.input, goal)
+    : null;
+  const plannedToolCall =
+    reply.toolCall && normalizedToolInput
+      ? {
+          id: reply.toolCall.id,
+          name: reply.toolCall.name,
+          input: normalizedToolInput,
+        }
+      : null;
+  const directAnswer = reply.content;
+  const nextAction = plannedToolCall
+    ? `Prepare a ${plannedToolCall.name} draft for "${readToolRun.inputText}".`
+    : directAnswer
+      ? "Ask the user for clarification before changing the file."
+      : "Fallback to the normal second planning step because the tool decision was invalid.";
+
+  return {
+    assistantMessage: reply.assistantMessage,
+    directAnswer,
+    nextAction,
+    plan: [
+      "Review the existing file content.",
+      "Apply the requested change safely.",
+      "Prepare a write draft for approval.",
+    ],
+    toolCallId: plannedToolCall?.id ?? null,
+    toolName: plannedToolCall?.name ?? null,
+    toolInput: plannedToolCall?.input ?? null,
+    step: createStep(
+      `think-${roundNumber}`,
+      "Think",
+      `Use the read_file result to prepare a safe modification draft for "${readToolRun.inputText}". Next action: ${nextAction}`,
+    ),
+  };
+}
+
+function thinkAfterIssueDetailForPlanning(
+  latestToolRun: ToolRun,
+  roundNumber: number,
+): ThoughtResult {
+  const plannedToolCall = deriveIssuePlanToolCallFromToolRun(latestToolRun);
+
+  if (!plannedToolCall) {
+    return {
+      assistantMessage: null,
+      directAnswer: null,
+      nextAction:
+        "Fallback to the normal planner because the issue detail did not contain enough structured content to build a plan safely.",
+      plan: [
+        "Review the issue detail that was just loaded.",
+        "Turn the issue into a code-change plan.",
+        "Return a concrete next step and validation path.",
+      ],
+      toolCallId: null,
+      toolName: null,
+      toolInput: null,
+      step: createStep(
+        `think-${roundNumber}`,
+        "Think",
+        "The latest git_inspect issue_detail result did not contain enough structured issue content, so fall back to the normal planner.",
+      ),
+    };
+  }
+
+  return {
+    assistantMessage: null,
+    directAnswer: null,
+    nextAction: `Use ${plannedToolCall.name} with input ${formatToolExecutionInput(plannedToolCall.input)}.`,
+    plan: [
+      "Review the structured issue detail that was just loaded.",
+      "Convert that issue detail into an executable code-change plan.",
+      "Return the plan before touching code.",
+    ],
+    toolCallId: plannedToolCall.id,
+    toolName: plannedToolCall.name,
+    toolInput: plannedToolCall.input,
+    step: createStep(
+      `think-${roundNumber}`,
+      "Think",
+      `Issue detail is already loaded, so convert it directly into an issue_plan with input ${formatToolExecutionInput(plannedToolCall.input)}.`,
+    ),
+  };
+}
+
+function thinkAfterIssuePlanForInvestigation(
+  latestToolRun: ToolRun,
+  roundNumber: number,
+): ThoughtResult {
+  const plannedToolCall = deriveIssueInvestigationToolCallFromToolRun(
+    latestToolRun,
+  );
+
+  if (!plannedToolCall) {
+    return {
+      assistantMessage: null,
+      directAnswer: null,
+      nextAction:
+        "Fallback to the normal planner because the issue plan did not contain a clear first investigation target.",
+      plan: [
+        "Review the code-change plan that was just created.",
+        "Choose the safest first investigation step.",
+        "Inspect code before editing anything.",
+      ],
+      toolCallId: null,
+      toolName: null,
+      toolInput: null,
+      step: createStep(
+        `think-${roundNumber}`,
+        "Think",
+        "The latest issue_plan did not include a clear file path or keyword, so fall back to the normal planner.",
+      ),
+    };
+  }
+
+  return {
+    assistantMessage: null,
+    directAnswer: null,
+    nextAction: `Use ${plannedToolCall.name} with input ${formatToolExecutionInput(plannedToolCall.input)}.`,
+    plan: [
+      "Review the code-change plan that was just created.",
+      "Use the plan to inspect one likely file or search one likely keyword.",
+      "Collect real code context before deciding the edit.",
+    ],
+    toolCallId: plannedToolCall.id,
+    toolName: plannedToolCall.name,
+    toolInput: plannedToolCall.input,
+    step: createStep(
+      `think-${roundNumber}`,
+      "Think",
+      `Issue plan is ready, so start investigation with ${plannedToolCall.name} using ${formatToolExecutionInput(plannedToolCall.input)}.`,
+    ),
+  };
+}
+
+export const thinkStrategies: ThinkStrategy[] = [
+  {
+    match: (toolRuns, goal) => {
+      const latestToolRun = toolRuns.at(-1);
+
+      return (
+        !!latestToolRun &&
+        latestToolRun.name === "read_file" &&
+        latestToolRun.result.ok &&
+        (isFileModificationRequest(goal) || isIssueDrivenReadForDraft(toolRuns))
+      );
+    },
+    think: ({
+      context,
+      perception,
+      roundNumber,
+      toolRuns,
+    }) => {
+      const latestToolRun = toolRuns.at(-1);
+
+      if (!latestToolRun) {
+        throw new Error("Expected latest tool run for read_file strategy.");
+      }
+
+      return thinkAfterReadForModification(
+        context,
+        perception.goal,
+        latestToolRun,
+        roundNumber,
+        getLatestIssuePlanText(toolRuns),
+      );
+    },
+  },
+  {
+    match: (toolRuns) => {
+      const latestToolRun = toolRuns.at(-1);
+
+      return !!latestToolRun && !!deriveIssuePlanToolCallFromToolRun(latestToolRun);
+    },
+    think: ({ roundNumber, toolRuns }) => {
+      const latestToolRun = toolRuns.at(-1);
+
+      if (!latestToolRun) {
+        throw new Error("Expected latest tool run for issue planning strategy.");
+      }
+
+      return thinkAfterIssueDetailForPlanning(latestToolRun, roundNumber);
+    },
+  },
+  {
+    match: (toolRuns) => {
+      const latestToolRun = toolRuns.at(-1);
+
+      return (
+        !!latestToolRun &&
+        !!deriveIssueInvestigationToolCallFromToolRun(latestToolRun)
+      );
+    },
+    think: ({ roundNumber, toolRuns }) => {
+      const latestToolRun = toolRuns.at(-1);
+
+      if (!latestToolRun) {
+        throw new Error("Expected latest tool run for issue investigation strategy.");
+      }
+
+      return thinkAfterIssuePlanForInvestigation(latestToolRun, roundNumber);
+    },
+  },
+];
+
+export async function answerWithToolResults(
+  context: AgentContext,
+  goal: string,
+  toolRuns: ToolRun[],
+) {
+  const response = await callModelForText(
+    context.model,
+    [
+      {
+        role: "system",
+        content:
+          "You are a stripped-down Codex-style coding assistant. Reply in the same language as the user. Be concise, practical, and clear. Use the completed tool results below to answer the user directly. If web_search was used, keep the result titles and links visible in the answer. If read_page was used, present the result as three labeled lines: final URL, page title, and a short visible text sample. Do not request another tool. Do not output tool-call markup, XML tags, or DSML blocks.",
+      },
+      {
+        role: "user",
+        content: [
+          "Older conversation summary:",
+          formatConversationSummaryForModel(context.sessionContext),
+          "",
+          "Recent conversation:",
+          formatConversationForModel(context.recentConversation),
+          "",
+          "Session reference hints:",
+          formatSessionContextForModel(context.sessionContext),
+          "",
+          `Original task: ${goal}`,
+          "",
+          "Completed tool results:",
+          formatToolRunsForModel(toolRuns),
+          "",
+          "Use only these completed results to answer the user directly.",
+        ].join("\n"),
+      },
+    ],
+  );
+
+  return response;
+}
+
+export async function answerDirectly(context: AgentContext, goal: string) {
+  const response = await callModelForText(context.model, [
+    {
+      role: "system",
+      content:
+        `You are a stripped-down Codex-style coding assistant. Reply in the same language as the user. Be concise, practical, and clear. Available tools for future steps: ${context.toolNames.join(", ")}.`,
+    },
+    {
+      role: "user",
+      content: [
+        "Older conversation summary:",
+        formatConversationSummaryForModel(context.sessionContext),
+        "",
+        "Recent conversation:",
+        formatConversationForModel(context.recentConversation),
+        "",
+        "Session reference hints:",
+        formatSessionContextForModel(context.sessionContext),
+        "",
+        `Current task: ${goal}`,
+      ].join("\n"),
+    },
+  ]);
+
+  return response;
+}

--- a/src/lib/agent/direct-tool-plans.ts
+++ b/src/lib/agent/direct-tool-plans.ts
@@ -5,6 +5,11 @@ import {
 } from "@/lib/agent/tool-run-types";
 import type { PlannedToolCall } from "@/lib/agent/model-client";
 
+type DirectToolPlanRule = {
+  derive: (goal: string) => DirectToolPlan | null;
+  match: (goal: string) => boolean;
+};
+
 function extractUrlFromTask(task: string) {
   const match = task.match(/https?:\/\/[^\s)>"']+|www\.[^\s)>"']+/i);
   return match?.[0]?.trim() ?? null;
@@ -381,6 +386,41 @@ export function derivePastedIssuePlanToolCall(
       issue_text: cleanTask,
     },
   };
+}
+
+const directToolPlanRules: DirectToolPlanRule[] = [
+  {
+    match: (goal) => !!extractUrlFromTask(goal) && !!deriveClickSelectorFromTask(goal),
+    derive: deriveDirectClickToolCall,
+  },
+  {
+    match: (goal) => !!derivePastedIssuePlanToolCall(goal),
+    derive: derivePastedIssuePlanToolCall,
+  },
+  {
+    match: (goal) => !!deriveDirectGitInspectToolCall(goal),
+    derive: deriveDirectGitInspectToolCall,
+  },
+  {
+    match: (goal) => !!deriveDirectSafeCommandToolCall(goal),
+    derive: deriveDirectSafeCommandToolCall,
+  },
+];
+
+export function deriveDirectToolPlan(goal: string) {
+  for (const rule of directToolPlanRules) {
+    if (!rule.match(goal)) {
+      continue;
+    }
+
+    const plan = rule.derive(goal);
+
+    if (plan) {
+      return plan;
+    }
+  }
+
+  return null;
 }
 
 function stripLeadingMatch(text: string, patterns: RegExp[]) {

--- a/src/lib/agent/issue-flow.ts
+++ b/src/lib/agent/issue-flow.ts
@@ -7,8 +7,8 @@ import {
 } from "@/lib/agent/tool-args";
 import {
   createSyntheticToolCallId,
-  type ToolRun,
 } from "@/lib/agent/tool-run-types";
+import type { ToolRun } from "@/lib/tools/types";
 import { getWorkspaceRoot } from "@/lib/tools/workspace-path";
 
 function taskLooksChinese(text: string) {

--- a/src/lib/agent/model-client.ts
+++ b/src/lib/agent/model-client.ts
@@ -34,16 +34,105 @@ export type LlmMessage = {
   }>;
 };
 
-function createModelClient() {
-  const apiKey = process.env.DEEPSEEK_API_KEY;
+export type ModelProvider = "anthropic" | "deepseek" | "openai";
+
+export type ModelClientConfig = {
+  apiKey?: string;
+  baseURL?: string;
+};
+
+function getConfiguredProvider(): ModelProvider {
+  const provider = process.env.MODEL_PROVIDER?.trim().toLowerCase();
+
+  if (!provider) {
+    return "deepseek";
+  }
+
+  if (
+    provider === "anthropic" ||
+    provider === "deepseek" ||
+    provider === "openai"
+  ) {
+    return provider;
+  }
+
+  throw new Error(
+    'MODEL_PROVIDER must be one of "deepseek", "openai", or "anthropic".',
+  );
+}
+
+function getProviderDefaults(provider: ModelProvider) {
+  if (provider === "deepseek") {
+    return {
+      apiKey: process.env.DEEPSEEK_API_KEY,
+      baseURL: process.env.DEEPSEEK_BASE_URL ?? "https://api.deepseek.com",
+      missingKeyMessage: "Missing DEEPSEEK_API_KEY.",
+    };
+  }
+
+  if (provider === "openai") {
+    return {
+      apiKey: process.env.OPENAI_API_KEY,
+      baseURL: process.env.OPENAI_BASE_URL,
+      missingKeyMessage: "Missing OPENAI_API_KEY.",
+    };
+  }
+
+  return {
+    apiKey: process.env.ANTHROPIC_API_KEY,
+    baseURL: process.env.ANTHROPIC_BASE_URL,
+    missingKeyMessage: "Missing ANTHROPIC_API_KEY.",
+  };
+}
+
+function getProviderExtraBody(provider: ModelProvider) {
+  if (provider !== "deepseek") {
+    return undefined;
+  }
+
+  return {
+    thinking: {
+      type: "disabled",
+    },
+  };
+}
+
+export function getConfiguredModelName() {
+  const provider = getConfiguredProvider();
+
+  if (provider === "deepseek") {
+    return process.env.DEEPSEEK_MODEL ?? "deepseek-v4-flash";
+  }
+
+  if (provider === "openai") {
+    return process.env.OPENAI_MODEL ?? "gpt-4.1-mini";
+  }
+
+  return process.env.ANTHROPIC_MODEL ?? "claude-sonnet-4-20250514";
+}
+
+function createModelClient(
+  provider: ModelProvider,
+  config: ModelClientConfig = {},
+) {
+  const defaults = getProviderDefaults(provider);
+  const apiKey = config.apiKey ?? defaults.apiKey;
 
   if (!apiKey) {
-    throw new Error("Missing DEEPSEEK_API_KEY.");
+    throw new Error(defaults.missingKeyMessage);
   }
+
+  if (provider === "anthropic" && !(config.baseURL ?? defaults.baseURL)) {
+    throw new Error(
+      "ANTHROPIC_BASE_URL is required because the current model client uses the OpenAI-compatible chat completions interface.",
+    );
+  }
+
+  const baseURL = config.baseURL ?? defaults.baseURL;
 
   return new OpenAI({
     apiKey,
-    baseURL: process.env.DEEPSEEK_BASE_URL ?? "https://api.deepseek.com",
+    ...(baseURL ? { baseURL } : {}),
   });
 }
 
@@ -112,14 +201,12 @@ export async function callModelForText(
   model: string,
   messages: LlmMessage[],
 ): Promise<ModelTextMessage> {
-  const response = await createModelClient().chat.completions.create({
+  const provider = getConfiguredProvider();
+  const extraBody = getProviderExtraBody(provider);
+  const response = await createModelClient(provider).chat.completions.create({
     model,
     messages,
-    extra_body: {
-      thinking: {
-        type: "disabled",
-      },
-    },
+    ...(extraBody ? { extra_body: extraBody } : {}),
   } as never);
 
   const message = response.choices[0]?.message;
@@ -137,16 +224,14 @@ export async function callModelForToolDecision(
   messages: LlmMessage[],
   allowedToolNames?: string[],
 ): Promise<ModelToolMessage> {
-  const response = await createModelClient().chat.completions.create({
+  const provider = getConfiguredProvider();
+  const extraBody = getProviderExtraBody(provider);
+  const response = await createModelClient(provider).chat.completions.create({
     model,
     messages,
     tools: buildModelTools(allowedToolNames),
     tool_choice: "auto",
-    extra_body: {
-      thinking: {
-        type: "disabled",
-      },
-    },
+    ...(extraBody ? { extra_body: extraBody } : {}),
   } as never);
 
   const message = response.choices[0]?.message;

--- a/src/lib/agent/run-agent.ts
+++ b/src/lib/agent/run-agent.ts
@@ -4,24 +4,14 @@ import type {
   AgentStep,
   ChatMessage,
 } from "@/types/agent";
+import { createLogger } from "@/lib/logger";
 import { listTools } from "@/lib/tools/tool-registry";
 import { withWorkspaceRoot } from "@/lib/tools/workspace-path";
-import type {
-  ToolCallArgs,
-  ToolExecutionInput,
-} from "@/lib/tools/types";
-import { createLogger } from "@/lib/logger";
 import {
-  formatConversationForModel,
-  formatConversationSummaryForModel,
   normalizeSessionContext,
   prepareConversationContext,
 } from "@/lib/agent/conversation-context";
-import {
-  callModelForText,
-  callModelForToolDecision,
-  type LlmMessage,
-} from "@/lib/agent/model-client";
+import { getConfiguredModelName } from "@/lib/agent/model-client";
 import {
   createMessage,
   createStep,
@@ -29,13 +19,7 @@ import {
   finishAgentRun,
   type RunAgentOptions,
 } from "@/lib/agent/agent-response";
-import {
-  getNumberArg,
-  getStringArg,
-  getStringArrayArg,
-  formatToolExecutionInput,
-  formatToolRunsForModel,
-} from "@/lib/agent/tool-args";
+import { formatToolExecutionInput } from "@/lib/agent/tool-args";
 import {
   APPROVE_WRITE_COMMAND,
   CANCEL_WRITE_COMMAND,
@@ -43,10 +27,7 @@ import {
   createSyntheticToolCallId,
   type ToolRun,
 } from "@/lib/agent/tool-run-types";
-import {
-  buildNextSessionContext,
-  formatSessionContextForModel,
-} from "@/lib/agent/session-state";
+import { buildNextSessionContext } from "@/lib/agent/session-state";
 import {
   handleWriteApproval,
   isAmbiguousDraftConfirmation,
@@ -55,351 +36,15 @@ import {
 } from "@/lib/agent/draft-lifecycle";
 import { runToolCall } from "@/lib/agent/tool-runner";
 import {
-  deriveIssueInvestigationToolCallFromToolRun,
-  deriveIssuePlanToolCallFromToolRun,
-  extractIssuePlanFromGitInspectReport,
-  formatIssueInvestigationAnswer,
-  getLatestIssuePlanText,
-  isIssueDrivenReadForDraft,
-  parseGitInspectAction,
-} from "@/lib/agent/issue-flow";
-import {
-  formatClickPageAnswer,
-  formatReadPageAnswer,
-} from "@/lib/agent/page-result-format";
-import {
-  deriveDirectClickToolCall,
-  deriveDirectGitInspectToolCall,
-  deriveDirectSafeCommandToolCall,
-  deriveFocusedWebSearchQuery,
-  derivePastedIssuePlanToolCall,
-  deriveWebSearchQueryFromTask,
-} from "@/lib/agent/direct-tool-plans";
+  answerDirectly,
+  answerWithToolResults,
+  isFileModificationRequest,
+  perceive,
+  think,
+  thinkStrategies,
+  type AgentContext,
+} from "@/lib/agent/agent-thinking";
 
-type AgentContext = {
-  cleanTask: string;
-  recentConversation: ChatMessage[];
-  sessionContext: AgentSessionContext;
-  model: string;
-  toolNames: string[];
-};
-
-type PerceptionResult = {
-  goal: string;
-  taskSize: string;
-  step: AgentStep;
-};
-
-type ThoughtResult = {
-  assistantMessage: LlmMessage | null;
-  directAnswer: string | null;
-  nextAction: string;
-  plan: string[];
-  step: AgentStep;
-  toolCallId: string | null;
-  toolInput: ToolExecutionInput | null;
-  toolName: string | null;
-};
-
-function getRemainingToolCalls(toolRuns: ToolRun[]) {
-  return Math.max(MAX_TOOL_CALLS - toolRuns.length, 0);
-}
-
-function buildThoughtPlan(toolRuns: ToolRun[], remainingToolCalls: number) {
-  if (toolRuns.length === 0) {
-    return [
-      "Understand what the user wants.",
-      "Ask the model whether it needs a tool.",
-      "Use the safest next action.",
-    ];
-  }
-
-  if (remainingToolCalls > 0) {
-    return [
-      "Review the latest tool result.",
-      "Decide whether another tool is still needed.",
-      "Answer now if the task is already complete.",
-    ];
-  }
-
-  return [
-    "Review the completed tool results.",
-    "Stop using tools.",
-    "Turn the results into a final answer.",
-  ];
-}
-
-function buildPlannerBudgetInstruction(toolRuns: ToolRun[], remainingToolCalls: number) {
-  if (toolRuns.length === 0) {
-    return "Choose between requesting the first tool or giving a direct answer.";
-  }
-
-  if (remainingToolCalls > 0) {
-    return `You have already seen ${toolRuns.length} tool result${toolRuns.length === 1 ? "" : "s"}. Choose one next tool call or give the final answer now.`;
-  }
-
-  return "No more tool calls remain. Give the final answer now.";
-}
-
-function getImmediateToolOutcome(goal: string, toolRuns: ToolRun[]) {
-  const toolRun = toolRuns.at(-1);
-
-  if (!toolRun) {
-    return null;
-  }
-
-  if ((toolRun.name === "read_page" || toolRun.name === "click_page") && !toolRun.result.ok) {
-    return {
-      actDetail: `Run "${toolRun.name}", stop after the tool failure, and return the tool error directly.`,
-      message: toolRun.result.content,
-    };
-  }
-
-  if (toolRun.name === "read_page" && toolRun.result.ok) {
-    const formattedReadPageAnswer = formatReadPageAnswer(goal, toolRun.result.content);
-
-    if (formattedReadPageAnswer) {
-      return {
-        actDetail:
-          `Run "${toolRun.name}" and return the page URL, title, and visible text sample directly in a fixed format.`,
-        message: formattedReadPageAnswer,
-      };
-    }
-  }
-
-  if (toolRun.name === "click_page" && toolRun.result.ok) {
-    const formattedClickPageAnswer = formatClickPageAnswer(goal, toolRun.result.content);
-
-    if (formattedClickPageAnswer) {
-      return {
-        actDetail:
-          `Run "${toolRun.name}" and return the clicked selector, page URL, title, and visible text sample directly in a fixed format.`,
-        message: formattedClickPageAnswer,
-      };
-    }
-  }
-
-  if (toolRun.result.draft) {
-    const draftPath = toolRun.result.draft.path ?? "the requested file";
-
-    return {
-      actDetail:
-        `Prepare a ${toolRun.name} draft for "${draftPath}" and stop for explicit approval without writing anything to disk.`,
-      message: toolRun.result.content,
-    };
-  }
-
-  if (
-    toolRun.name === "safe_command" &&
-    isVerificationSafeCommandInput(toolRun.input)
-  ) {
-    return {
-      actDetail:
-        `Run "${toolRun.name}" for repository or build verification, then return the structured command report directly.`,
-      message: toolRun.result.content,
-    };
-  }
-
-  if (
-    toolRun.name === "git_inspect" &&
-    toolRun.result.ok &&
-    parseGitInspectAction(toolRun.result.content) === "issue_plan"
-  ) {
-    const issuePlan = extractIssuePlanFromGitInspectReport(toolRun.result.content);
-
-    if (issuePlan && !deriveIssueInvestigationToolCallFromToolRun(toolRun)) {
-      return {
-        actDetail:
-          `Run "${toolRun.name}" to turn the issue into a concrete code-change plan, then return that plan directly.`,
-        message: issuePlan,
-      };
-    }
-  }
-
-  const issueInvestigationAnswer = formatIssueInvestigationAnswer(goal, toolRuns);
-
-  if (issueInvestigationAnswer && !isIssueDrivenReadForDraft(toolRuns)) {
-    return {
-      actDetail:
-        `Run "${toolRun.name}" as the first issue investigation step, then return a concrete next-step summary instead of continuing to edit code immediately.`,
-      message: issueInvestigationAnswer,
-    };
-  }
-
-  return null;
-}
-
-function isVerificationSafeCommandInput(input: ToolExecutionInput) {
-  if (typeof input === "string") {
-    return false;
-  }
-
-  const command = getStringArg(input, "command").toLowerCase();
-  const args = getStringArrayArg(input, "args");
-
-  if (command === "git" && args.length === 1 && args[0] === "status") {
-    return true;
-  }
-
-  return (
-    command === "npm" &&
-    ((args.length === 2 && args[0] === "run" && args[1] === "build") ||
-      (args.length === 1 && args[0] === "test"))
-  );
-}
-
-function normalizeToolInput(toolName: string, rawInput: ToolCallArgs, task: string) {
-  if (toolName === "list_files") {
-    return {
-      path: getStringArg(rawInput, "path") || ".",
-    };
-  }
-
-  if (toolName === "read_file") {
-    const path = getStringArg(rawInput, "path");
-
-    if (!path) {
-      return null;
-    }
-
-    const startLine = getNumberArg(rawInput, "start_line");
-    const maxLines = getNumberArg(rawInput, "max_lines");
-
-    return {
-      path,
-      ...(startLine === null ? {} : { start_line: startLine }),
-      ...(maxLines === null ? {} : { max_lines: maxLines }),
-    };
-  }
-
-  if (toolName === "read_page") {
-    const url = getStringArg(rawInput, "url");
-    const maxChars = getNumberArg(rawInput, "max_chars");
-
-    if (!url) {
-      return null;
-    }
-
-    return maxChars === null ? { url } : { url, max_chars: maxChars };
-  }
-
-  if (toolName === "click_page") {
-    const url = getStringArg(rawInput, "url");
-    const selector = getStringArg(rawInput, "selector");
-    const maxChars = getNumberArg(rawInput, "max_chars");
-
-    if (!url || !selector) {
-      return null;
-    }
-
-    return maxChars === null
-      ? { url, selector }
-      : { url, selector, max_chars: maxChars };
-  }
-
-  if (toolName === "write_file") {
-    const path = getStringArg(rawInput, "path");
-    const contentValue = rawInput.content;
-    const content = typeof contentValue === "string" ? contentValue : null;
-
-    if (!path || content === null) {
-      return null;
-    }
-
-    return {
-      path,
-      content,
-    };
-  }
-
-  if (toolName === "replace_text") {
-    const path = getStringArg(rawInput, "path");
-    const oldTextValue = rawInput.old_text;
-    const newTextValue = rawInput.new_text;
-    const oldText = typeof oldTextValue === "string" ? oldTextValue : null;
-    const newText = typeof newTextValue === "string" ? newTextValue : null;
-
-    if (!path || oldText === null || oldText.length === 0 || newText === null) {
-      return null;
-    }
-
-    return {
-      path,
-      old_text: oldText,
-      new_text: newText,
-    };
-  }
-
-  if (toolName === "search_text") {
-    const query = getStringArg(rawInput, "query");
-    const path = getStringArg(rawInput, "path");
-
-    if (!query) {
-      return null;
-    }
-
-    return path ? { query, path } : { query };
-  }
-
-  if (toolName === "safe_command") {
-    const command = getStringArg(rawInput, "command").toLowerCase();
-    const args = getStringArrayArg(rawInput, "args");
-
-    if (!command || args.length === 0) {
-      return null;
-    }
-
-    return {
-      command,
-      args,
-    };
-  }
-
-  if (toolName === "web_search") {
-    const query = getStringArg(rawInput, "query");
-
-    return {
-      query: deriveFocusedWebSearchQuery(deriveWebSearchQueryFromTask(query || task)),
-    };
-  }
-
-  return rawInput;
-}
-
-function perceive(context: AgentContext): PerceptionResult {
-  const wordCount = context.cleanTask.split(/\s+/).filter(Boolean).length;
-  const taskSize = wordCount <= 6 ? "small" : "multi-part";
-
-  return {
-    goal: context.cleanTask,
-    taskSize,
-    step: createStep(
-      "perceive",
-      "Perceive",
-      `Read the task, clean the input, and identify the goal: "${context.cleanTask}". The task looks ${taskSize}. Recent conversation messages available: ${context.recentConversation.length}. Reference hints available: ${context.sessionContext.pendingDraft ? "pending draft" : "no pending draft"}.`,
-    ),
-  };
-}
-
-function buildMessagesWithToolRuns(baseMessages: LlmMessage[], toolRuns: ToolRun[]) {
-  const toolMessages = toolRuns.flatMap((toolRun) => [
-    toolRun.assistantMessage,
-    {
-      role: "tool" as const,
-      tool_call_id: toolRun.toolCallId,
-      content: toolRun.result.content,
-    },
-  ]);
-
-  return [...baseMessages, ...toolMessages];
-}
-
-function isFileModificationRequest(task: string) {
-  return (
-    /(modify|edit|update|change|append|replace|rewrite|revise|write|create|overwrite|delete|remove)/i.test(task) ||
-    /(修改|编辑|更新|改动|追加|替换|重写|删除|增加)/u.test(task)
-  );
-}
 function createReadOnlyBlockedResponse(
   sessionContext: AgentSessionContext,
 ): AgentResponse {
@@ -430,508 +75,6 @@ function createReadOnlyBlockedResponse(
       ),
     ],
   };
-}
-
-async function think(
-  context: AgentContext,
-  perception: PerceptionResult,
-  toolRuns: ToolRun[],
-): Promise<ThoughtResult> {
-  const readOnly = context.sessionContext.readOnly === true;
-  const availableTools = listTools({ readOnly });
-  const roundNumber = toolRuns.length + 1;
-  const remainingToolCalls = getRemainingToolCalls(toolRuns);
-  const plan = buildThoughtPlan(toolRuns, remainingToolCalls);
-
-  const toolList = availableTools
-    .map(
-      (tool) =>
-        `- ${tool.name}: ${tool.description} Input form: ${JSON.stringify(tool.inputSchema)}`,
-    )
-    .join("\n");
-
-  const directClickToolCall =
-    toolRuns.length === 0 ? deriveDirectClickToolCall(perception.goal) : null;
-  const directPastedIssuePlanToolCall =
-    toolRuns.length === 0 ? derivePastedIssuePlanToolCall(perception.goal) : null;
-  const directGitInspectToolCall =
-    toolRuns.length === 0 ? deriveDirectGitInspectToolCall(perception.goal) : null;
-  const directSafeCommandToolCall =
-    toolRuns.length === 0 ? deriveDirectSafeCommandToolCall(perception.goal) : null;
-
-  if (directClickToolCall) {
-    return {
-      assistantMessage: null,
-      directAnswer: null,
-      nextAction: `Use ${directClickToolCall.name} with input ${formatToolExecutionInput(directClickToolCall.input)}.`,
-      plan,
-      toolCallId: directClickToolCall.id,
-      toolName: directClickToolCall.name,
-      toolInput: directClickToolCall.input,
-      step: createStep(
-        `think-${roundNumber}`,
-        "Think",
-        `Plan round ${roundNumber}: ${plan.join(" ")} Available tools: ${availableTools.map((tool) => tool.name).join(", ")}. Next action: Use ${directClickToolCall.name} with input ${formatToolExecutionInput(directClickToolCall.input)}.`,
-      ),
-    };
-  }
-
-  if (directPastedIssuePlanToolCall) {
-    return {
-      assistantMessage: null,
-      directAnswer: null,
-      nextAction: `Use ${directPastedIssuePlanToolCall.name} with input ${formatToolExecutionInput(directPastedIssuePlanToolCall.input)}.`,
-      plan,
-      toolCallId: directPastedIssuePlanToolCall.id,
-      toolName: directPastedIssuePlanToolCall.name,
-      toolInput: directPastedIssuePlanToolCall.input,
-      step: createStep(
-        `think-${roundNumber}`,
-        "Think",
-        `Plan round ${roundNumber}: ${plan.join(" ")} Available tools: ${availableTools.map((tool) => tool.name).join(", ")}. Next action: Use ${directPastedIssuePlanToolCall.name} with input ${formatToolExecutionInput(directPastedIssuePlanToolCall.input)}.`,
-      ),
-    };
-  }
-
-  if (directGitInspectToolCall) {
-    return {
-      assistantMessage: null,
-      directAnswer: null,
-      nextAction: `Use ${directGitInspectToolCall.name} with input ${formatToolExecutionInput(directGitInspectToolCall.input)}.`,
-      plan,
-      toolCallId: directGitInspectToolCall.id,
-      toolName: directGitInspectToolCall.name,
-      toolInput: directGitInspectToolCall.input,
-      step: createStep(
-        `think-${roundNumber}`,
-        "Think",
-        `Plan round ${roundNumber}: ${plan.join(" ")} Available tools: ${availableTools.map((tool) => tool.name).join(", ")}. Next action: Use ${directGitInspectToolCall.name} with input ${formatToolExecutionInput(directGitInspectToolCall.input)}.`,
-      ),
-    };
-  }
-
-  if (directSafeCommandToolCall) {
-    return {
-      assistantMessage: null,
-      directAnswer: null,
-      nextAction: `Use ${directSafeCommandToolCall.name} with input ${formatToolExecutionInput(directSafeCommandToolCall.input)}.`,
-      plan,
-      toolCallId: directSafeCommandToolCall.id,
-      toolName: directSafeCommandToolCall.name,
-      toolInput: directSafeCommandToolCall.input,
-      step: createStep(
-        `think-${roundNumber}`,
-        "Think",
-        `Plan round ${roundNumber}: ${plan.join(" ")} Available tools: ${availableTools.map((tool) => tool.name).join(", ")}. Next action: Use ${directSafeCommandToolCall.name} with input ${formatToolExecutionInput(directSafeCommandToolCall.input)}.`,
-      ),
-    };
-  }
-
-  const plannerReply = await callModelForToolDecision(
-    context.model,
-    buildMessagesWithToolRuns(
-      [
-        {
-          role: "system",
-          content: [
-            "You are the planning step for a stripped-down coding agent.",
-            "You may request at most one tool in each reply.",
-            `The full user request may use at most ${MAX_TOOL_CALLS} tool calls total.`,
-            buildPlannerBudgetInstruction(toolRuns, remainingToolCalls),
-            readOnly
-              ? "This session is read-only. Do not modify files. The write_file and replace_text tools are unavailable."
-              : "",
-            "If the user wants to modify an existing file, first use read_file to get the current content.",
-            "If the user asks for one exact text replacement inside an existing file, prefer replace_text after read_file.",
-            "If the user asks to create, edit, or overwrite a file and the change is broader than one exact replacement, prefer the write_file tool.",
-            "If the user asks to open a web page, inspect a URL, or read page content from a live site, prefer read_page.",
-            "If the user asks to click one simple link, button, or tab on a live page, prefer click_page.",
-            "If the user asks whether the current workspace is a Git repository, prefer git_inspect with action check_repo.",
-            "If the user asks for one specific issue detail, prefer git_inspect with action issue_detail and include the issue_number.",
-            'If the user asks you to turn an issue into an execution plan, prefer git_inspect with action issue_plan. Pass pasted issue text in issue_text, or pass issue_number when the user names one GitHub issue number.',
-            "If the user asks for the current repository issue list, prefer git_inspect with action issue_list.",
-            "If the user asks for current GitHub repository info, prefer git_inspect with action repo_info.",
-            "If the user asks for a PR draft suggestion, prefer git_inspect with action pr_draft.",
-            "If the user asks to export a patch, generate patch text, or produce a diff patch, prefer git_inspect with action patch_export. This is read-only and must not commit or push.",
-            "If the user asks for a task_submit draft or task submit text, prefer git_inspect with action task_submit. This is read-only and must not commit, push, or actually submit anything.",
-            "If the user asks for a commit message suggestion, prefer git_inspect with action commit_message.",
-            "If the user asks whether the workspace is connected to GitHub, or asks about remotes, GitHub remotes, gh CLI, or GitHub login readiness, prefer git_inspect with action github_env.",
-            "If the user asks for git status or repository status, prefer git_inspect with action status.",
-            "If the user asks for git diff or repository diff, prefer git_inspect with action diff.",
-            "If the user asks for a Git change summary, prefer git_inspect with action summary.",
-            "If the user explicitly asks to run a local command, prefer safe_command instead of inventing shell output.",
-            "If the user asks to build, compile, or verify whether the project still builds, prefer safe_command with npm run build.",
-            "If the user asks you to search the web, look something up online, or needs current public information, prefer web_search.",
-            "Available tools:",
-            toolList,
-            "If you need one tool, call exactly one tool using the provided function definitions.",
-            "Fill tool arguments as JSON that matches the tool's input form.",
-            "Do not use safe_command for network access, shell wrappers, or any command outside its allowlist.",
-            "If you do not need a tool, answer normally in plain text.",
-          ].join("\n"),
-        },
-        {
-          role: "user",
-          content: [
-            "Older conversation summary:",
-            formatConversationSummaryForModel(context.sessionContext),
-            "",
-            "Recent conversation:",
-            formatConversationForModel(context.recentConversation),
-            "",
-            "Session reference hints:",
-            formatSessionContextForModel(context.sessionContext),
-            "",
-            `Original task: ${perception.goal}`,
-            `Tool calls already used: ${toolRuns.length}`,
-            `Tool calls remaining: ${remainingToolCalls}`,
-          ].join("\n"),
-        },
-      ],
-      toolRuns,
-    ),
-    context.toolNames,
-  );
-
-  const normalizedToolInput = plannerReply.toolCall
-    ? normalizeToolInput(
-        plannerReply.toolCall.name,
-        plannerReply.toolCall.input,
-        perception.goal,
-      )
-    : null;
-  const plannedToolCall =
-    plannerReply.toolCall && normalizedToolInput
-      ? {
-          id: plannerReply.toolCall.id,
-          name: plannerReply.toolCall.name,
-          input: normalizedToolInput,
-        }
-      : null;
-  const chosenToolInput = plannedToolCall?.input ?? null;
-  const directAnswer = plannerReply.content;
-
-  const nextAction = plannedToolCall
-    ? `Use ${plannedToolCall.name} with input ${formatToolExecutionInput(chosenToolInput ?? plannedToolCall.input)}.`
-    : directAnswer
-      ? "Return the model's direct answer."
-      : "Fallback to a direct model answer because the tool decision was invalid.";
-
-  return {
-    assistantMessage: plannerReply.assistantMessage,
-    directAnswer,
-    nextAction,
-    plan,
-    toolCallId: plannedToolCall?.id ?? null,
-    toolName: plannedToolCall?.name ?? null,
-    toolInput: chosenToolInput,
-    step: createStep(
-      `think-${roundNumber}`,
-      "Think",
-      `Plan round ${roundNumber}: ${plan.join(" ")} Available tools: ${availableTools.map((tool) => tool.name).join(", ")}. Next action: ${nextAction}`,
-    ),
-  };
-}
-
-async function thinkAfterReadForModification(
-  context: AgentContext,
-  goal: string,
-  readToolRun: ToolRun,
-  roundNumber: number,
-  issuePlanText?: string | null,
-): Promise<ThoughtResult> {
-  if (context.sessionContext.readOnly) {
-    return {
-      assistantMessage: null,
-      directAnswer:
-        "Current session is read-only, so I cannot prepare a file modification draft. Exit read-only mode before asking me to modify files.",
-      nextAction: "Return a read-only mode refusal instead of preparing a write draft.",
-      plan: [
-        "Review the existing file content.",
-        "Notice that this session is read-only.",
-        "Stop before preparing a write draft.",
-      ],
-      toolCallId: null,
-      toolName: null,
-      toolInput: null,
-      step: createStep(
-        `think-${roundNumber}`,
-        "Think",
-        "This session is read-only, so file modification tools are disabled.",
-      ),
-    };
-  }
-
-  const reply = await callModelForToolDecision(
-    context.model,
-    buildMessagesWithToolRuns(
-      [
-        {
-          role: "system",
-          content: [
-            "You are the editing step for a stripped-down coding agent.",
-            "The user wants to modify an existing file.",
-            "You already have the current file content from read_file.",
-            "If one exact old snippet can be safely replaced with one new snippet, call the replace_text tool first.",
-            "If the change is broader than one exact replacement, call the write_file tool.",
-            "The write_file content argument must contain the full final file content, not a diff.",
-            issuePlanText
-              ? "This read_file step came from an issue execution plan. If the likely fix is clear enough from the issue plan plus the current file content, prepare the smallest safe draft now."
-              : "Work only from the explicit user edit request and the current file content.",
-            "If the change request is too ambiguous to apply safely, ask the user one short clarifying question in plain text.",
-          ].join("\n"),
-        },
-        {
-          role: "user",
-          content: [
-            "Older conversation summary:",
-            formatConversationSummaryForModel(context.sessionContext),
-            "",
-            "Recent conversation:",
-            formatConversationForModel(context.recentConversation),
-            "",
-            "Session reference hints:",
-            formatSessionContextForModel(context.sessionContext),
-            "",
-            `Original task: ${goal}`,
-            `Target file path: ${readToolRun.inputText}`,
-            issuePlanText ? "" : null,
-            issuePlanText ? "Issue execution plan:" : null,
-            issuePlanText ?? null,
-          ].join("\n"),
-        },
-      ],
-      [readToolRun],
-    ),
-    ["replace_text", "write_file"],
-  );
-
-  const normalizedToolInput = reply.toolCall
-    ? normalizeToolInput(reply.toolCall.name, reply.toolCall.input, goal)
-    : null;
-  const plannedToolCall =
-    reply.toolCall && normalizedToolInput
-      ? {
-          id: reply.toolCall.id,
-          name: reply.toolCall.name,
-          input: normalizedToolInput,
-        }
-      : null;
-  const directAnswer = reply.content;
-  const nextAction = plannedToolCall
-    ? `Prepare a ${plannedToolCall.name} draft for "${readToolRun.inputText}".`
-    : directAnswer
-      ? "Ask the user for clarification before changing the file."
-      : "Fallback to the normal second planning step because the tool decision was invalid.";
-
-  return {
-    assistantMessage: reply.assistantMessage,
-    directAnswer,
-    nextAction,
-    plan: [
-      "Review the existing file content.",
-      "Apply the requested change safely.",
-      "Prepare a write draft for approval.",
-    ],
-    toolCallId: plannedToolCall?.id ?? null,
-    toolName: plannedToolCall?.name ?? null,
-    toolInput: plannedToolCall?.input ?? null,
-    step: createStep(
-      `think-${roundNumber}`,
-      "Think",
-      `Use the read_file result to prepare a safe modification draft for "${readToolRun.inputText}". Next action: ${nextAction}`,
-    ),
-  };
-}
-
-function thinkAfterIssueDetailForPlanning(
-  latestToolRun: ToolRun,
-  roundNumber: number,
-): ThoughtResult {
-  const plannedToolCall = deriveIssuePlanToolCallFromToolRun(latestToolRun);
-
-  if (!plannedToolCall) {
-    return {
-      assistantMessage: null,
-      directAnswer: null,
-      nextAction:
-        "Fallback to the normal planner because the issue detail did not contain enough structured content to build a plan safely.",
-      plan: [
-        "Review the issue detail that was just loaded.",
-        "Turn the issue into a code-change plan.",
-        "Return a concrete next step and validation path.",
-      ],
-      toolCallId: null,
-      toolName: null,
-      toolInput: null,
-      step: createStep(
-        `think-${roundNumber}`,
-        "Think",
-        "The latest git_inspect issue_detail result did not contain enough structured issue content, so fall back to the normal planner.",
-      ),
-    };
-  }
-
-  return {
-    assistantMessage: null,
-    directAnswer: null,
-    nextAction: `Use ${plannedToolCall.name} with input ${formatToolExecutionInput(plannedToolCall.input)}.`,
-    plan: [
-      "Review the structured issue detail that was just loaded.",
-      "Convert that issue detail into an executable code-change plan.",
-      "Return the plan before touching code.",
-    ],
-    toolCallId: plannedToolCall.id,
-    toolName: plannedToolCall.name,
-    toolInput: plannedToolCall.input,
-    step: createStep(
-      `think-${roundNumber}`,
-      "Think",
-      `Issue detail is already loaded, so convert it directly into an issue_plan with input ${formatToolExecutionInput(plannedToolCall.input)}.`,
-    ),
-  };
-}
-
-function thinkAfterIssuePlanForInvestigation(
-  latestToolRun: ToolRun,
-  roundNumber: number,
-): ThoughtResult {
-  const plannedToolCall = deriveIssueInvestigationToolCallFromToolRun(
-    latestToolRun,
-  );
-
-  if (!plannedToolCall) {
-    return {
-      assistantMessage: null,
-      directAnswer: null,
-      nextAction:
-        "Fallback to the normal planner because the issue plan did not contain a clear first investigation target.",
-      plan: [
-        "Review the code-change plan that was just created.",
-        "Choose the safest first investigation step.",
-        "Inspect code before editing anything.",
-      ],
-      toolCallId: null,
-      toolName: null,
-      toolInput: null,
-      step: createStep(
-        `think-${roundNumber}`,
-        "Think",
-        "The latest issue_plan did not include a clear file path or keyword, so fall back to the normal planner.",
-      ),
-    };
-  }
-
-  return {
-    assistantMessage: null,
-    directAnswer: null,
-    nextAction: `Use ${plannedToolCall.name} with input ${formatToolExecutionInput(plannedToolCall.input)}.`,
-    plan: [
-      "Review the code-change plan that was just created.",
-      "Use the plan to inspect one likely file or search one likely keyword.",
-      "Collect real code context before deciding the edit.",
-    ],
-    toolCallId: plannedToolCall.id,
-    toolName: plannedToolCall.name,
-    toolInput: plannedToolCall.input,
-    step: createStep(
-      `think-${roundNumber}`,
-      "Think",
-      `Issue plan is ready, so start investigation with ${plannedToolCall.name} using ${formatToolExecutionInput(plannedToolCall.input)}.`,
-    ),
-  };
-}
-
-async function answerWithToolResults(
-  context: AgentContext,
-  goal: string,
-  toolRuns: ToolRun[],
-) {
-  if (toolRuns.length === 1 && toolRuns[0]?.name === "read_page") {
-    const formattedReadPageAnswer = formatReadPageAnswer(
-      goal,
-      toolRuns[0].result.content,
-    );
-
-    if (formattedReadPageAnswer) {
-      return {
-        content: formattedReadPageAnswer,
-      };
-    }
-  }
-
-  if (toolRuns.length === 1 && toolRuns[0]?.name === "click_page") {
-    const formattedClickPageAnswer = formatClickPageAnswer(
-      goal,
-      toolRuns[0].result.content,
-    );
-
-    if (formattedClickPageAnswer) {
-      return {
-        content: formattedClickPageAnswer,
-      };
-    }
-  }
-
-  const response = await callModelForText(
-    context.model,
-    [
-      {
-        role: "system",
-        content:
-          "You are a stripped-down Codex-style coding assistant. Reply in the same language as the user. Be concise, practical, and clear. Use the completed tool results below to answer the user directly. If web_search was used, keep the result titles and links visible in the answer. If read_page was used, present the result as three labeled lines: final URL, page title, and a short visible text sample. Do not request another tool. Do not output tool-call markup, XML tags, or DSML blocks.",
-      },
-      {
-        role: "user",
-        content: [
-          "Older conversation summary:",
-          formatConversationSummaryForModel(context.sessionContext),
-          "",
-          "Recent conversation:",
-          formatConversationForModel(context.recentConversation),
-          "",
-          "Session reference hints:",
-          formatSessionContextForModel(context.sessionContext),
-          "",
-          `Original task: ${goal}`,
-          "",
-          "Completed tool results:",
-          formatToolRunsForModel(toolRuns),
-          "",
-          "Use only these completed results to answer the user directly.",
-        ].join("\n"),
-      },
-    ],
-  );
-
-  return response;
-}
-
-async function answerDirectly(context: AgentContext, goal: string) {
-  const response = await callModelForText(context.model, [
-    {
-      role: "system",
-      content:
-        `You are a stripped-down Codex-style coding assistant. Reply in the same language as the user. Be concise, practical, and clear. Available tools for future steps: ${context.toolNames.join(", ")}.`,
-    },
-    {
-      role: "user",
-      content: [
-        "Older conversation summary:",
-        formatConversationSummaryForModel(context.sessionContext),
-        "",
-        "Recent conversation:",
-        formatConversationForModel(context.recentConversation),
-        "",
-        "Session reference hints:",
-        formatSessionContextForModel(context.sessionContext),
-        "",
-        `Current task: ${goal}`,
-      ].join("\n"),
-    },
-  ]);
-
-  return response;
 }
 
 export async function runAgent(
@@ -1054,9 +197,9 @@ export async function runAgent(
             `Draft id: ${effectiveSessionContext.pendingDraft.id}`,
             `Target path: ${effectiveSessionContext.pendingDraft.path}`,
             `If you want to write it, say: ${APPROVE_WRITE_COMMAND} ${effectiveSessionContext.pendingDraft.id}`,
-            `Or simply reply: approve / 批准`,
+            `Or simply reply: approve / 鎵瑰噯`,
             `If you want to discard it, say: ${CANCEL_WRITE_COMMAND} ${effectiveSessionContext.pendingDraft.id}`,
-            `Or simply reply: cancel / 取消`,
+            `Or simply reply: cancel / 鍙栨秷`,
           ].join("\n"),
         ),
         sessionContext: effectiveSessionContext,
@@ -1194,11 +337,7 @@ export async function runAgent(
     );
   }
 
-  if (!process.env.DEEPSEEK_API_KEY) {
-    throw new Error("Missing DEEPSEEK_API_KEY.");
-  }
-
-  const model = process.env.DEEPSEEK_MODEL ?? "deepseek-v4-flash";
+  const model = getConfiguredModelName();
   const preparedConversationContext = await prepareConversationContext(
     model,
     messages,
@@ -1233,27 +372,12 @@ export async function runAgent(
   while (true) {
     const roundNumber = toolRuns.length + 1;
     logger.info("agent loop iteration start", { loopCount: roundNumber });
-    const latestToolRun = toolRuns.at(-1) ?? null;
-    const thought =
-      latestToolRun &&
-      latestToolRun.name === "read_file" &&
-      latestToolRun.result.ok &&
-      (isFileModificationRequest(perception.goal) ||
-        isIssueDrivenReadForDraft(toolRuns))
-        ? await thinkAfterReadForModification(
-            context,
-            perception.goal,
-            latestToolRun,
-            roundNumber,
-            getLatestIssuePlanText(toolRuns),
-          )
-        : latestToolRun &&
-            deriveIssuePlanToolCallFromToolRun(latestToolRun)
-          ? thinkAfterIssueDetailForPlanning(latestToolRun, roundNumber)
-        : latestToolRun &&
-            deriveIssueInvestigationToolCallFromToolRun(latestToolRun)
-          ? thinkAfterIssuePlanForInvestigation(latestToolRun, roundNumber)
-        : await think(context, perception, toolRuns);
+    const strategy = thinkStrategies.find((strategy) =>
+      strategy.match(toolRuns, perception.goal),
+    );
+    const thought = strategy
+      ? await strategy.think({ context, perception, roundNumber, toolRuns })
+      : await think(context, perception, toolRuns);
 
     await pushStep(thought.step);
 
@@ -1263,16 +387,17 @@ export async function runAgent(
           ? thought.directAnswer
             ? {
                 content: thought.directAnswer,
-                reasoning_content: thought.assistantMessage?.reasoning_content ?? null,
+                reasoning_content:
+                  thought.assistantMessage?.reasoning_content ?? null,
               }
             : await answerDirectly(context, perception.goal)
           : thought.directAnswer
             ? {
                 content: thought.directAnswer,
-                reasoning_content: thought.assistantMessage?.reasoning_content ?? null,
+                reasoning_content:
+                  thought.assistantMessage?.reasoning_content ?? null,
               }
-            :
-            (await answerWithToolResults(context, perception.goal, toolRuns));
+            : await answerWithToolResults(context, perception.goal, toolRuns);
 
       await pushStep(
         createStep(
@@ -1281,7 +406,7 @@ export async function runAgent(
           toolRuns.length === 0
             ? thought.directAnswer
               ? "Return the model's direct answer without using a tool."
-              : `Call DeepSeek model "${context.model}" and return one assistant message to the chat UI.`
+              : `Call model "${context.model}" and return one assistant message to the chat UI.`
             : thought.directAnswer
               ? `Return the model's final answer after reviewing ${toolRuns.length} tool result${toolRuns.length === 1 ? "" : "s"}.`
               : `Use the ${toolRuns.length} completed tool result${toolRuns.length === 1 ? "" : "s"} to build a final answer because the planning reply did not request another tool.`,
@@ -1360,10 +485,18 @@ export async function runAgent(
       ),
     );
 
-    const immediateOutcome = getImmediateToolOutcome(perception.goal, toolRuns);
-    if (immediateOutcome) {
+    const immediateOutcome = toolRun.tool.onResult?.(
+      perception.goal,
+      toolRun.result,
+      toolRuns,
+    );
+    if (immediateOutcome?.type === "immediate") {
       await replaceLastStep(
-        createStep(`act-${roundNumber}`, "Act", immediateOutcome.actDetail),
+        createStep(
+          `act-${roundNumber}`,
+          "Act",
+          `Run "${toolRun.name}" and return its immediate tool result directly.`,
+        ),
       );
 
       return finishWithLogging(
@@ -1378,7 +511,11 @@ export async function runAgent(
     }
 
     if (toolRuns.length >= MAX_TOOL_CALLS) {
-      const finalReply = await answerWithToolResults(context, perception.goal, toolRuns);
+      const finalReply = await answerWithToolResults(
+        context,
+        perception.goal,
+        toolRuns,
+      );
 
       await replaceLastStep(
         createStep(

--- a/src/lib/agent/tool-run-types.ts
+++ b/src/lib/agent/tool-run-types.ts
@@ -1,4 +1,8 @@
-import type { ToolExecutionInput, ToolResult } from "@/lib/tools/types";
+import type {
+  AgentTool,
+  ToolExecutionInput,
+  ToolRun as ToolRunBase,
+} from "@/lib/tools/types";
 import type { LlmMessage } from "@/lib/agent/model-client";
 
 export type DirectToolPlan = {
@@ -7,15 +11,12 @@ export type DirectToolPlan = {
   name: string;
 };
 
-export type ToolRun = {
+export type ToolRun = ToolRunBase & {
   assistantMessage: LlmMessage;
   durationMs?: number;
   finishedAt?: number;
-  input: ToolExecutionInput;
-  inputText: string;
-  name: string;
-  result: ToolResult;
   startedAt?: number;
+  tool: AgentTool;
   toolCallId: string;
 };
 

--- a/src/lib/agent/tool-runner.ts
+++ b/src/lib/agent/tool-runner.ts
@@ -38,6 +38,7 @@ export async function runToolCall(
         ].join("\n"),
       },
       startedAt,
+      tool,
       toolCallId,
     };
   }
@@ -54,6 +55,7 @@ export async function runToolCall(
     inputText,
     result,
     startedAt,
+    tool,
     toolCallId,
   };
 }

--- a/src/lib/tools/click-page.ts
+++ b/src/lib/tools/click-page.ts
@@ -6,6 +6,7 @@ import type {
 } from "@/lib/tools/types";
 import { launchPlaywrightChromium } from "@/lib/tools/playwright-browser";
 import { assertSafeUrl } from "@/lib/tools/url-guard";
+import { formatClickPageAnswer } from "@/lib/agent/page-result-format";
 
 const NAVIGATION_TIMEOUT_MS = 15_000;
 const CLICK_TIMEOUT_MS = 8_000;
@@ -268,4 +269,21 @@ export const clickPageTool: AgentTool = {
     additionalProperties: false,
   },
   execute: executeClickPage,
+  onResult(goal, result) {
+    if (!result.ok) {
+      return {
+        type: "immediate",
+        message: result.content,
+      };
+    }
+
+    const formattedClickPageAnswer = formatClickPageAnswer(goal, result.content);
+
+    return formattedClickPageAnswer
+      ? {
+          type: "immediate",
+          message: formattedClickPageAnswer,
+        }
+      : null;
+  },
 };

--- a/src/lib/tools/git-inspect.ts
+++ b/src/lib/tools/git-inspect.ts
@@ -6,6 +6,11 @@ import type {
   ToolResult,
 } from "@/lib/tools/types";
 import { getWorkspaceRoot } from "@/lib/tools/workspace-path";
+import {
+  deriveIssueInvestigationToolCallFromToolRun,
+  extractIssuePlanFromGitInspectReport,
+  parseGitInspectAction,
+} from "@/lib/agent/issue-flow";
 
 const execFileAsync = promisify(execFile);
 const MAX_DIFF_PREVIEW_LENGTH = 12_000;
@@ -2589,4 +2594,26 @@ export const gitInspectTool: AgentTool = {
     additionalProperties: false,
   },
   execute: executeGitInspect,
+  onResult(_goal, result, toolRuns) {
+    const toolRun = toolRuns.at(-1);
+
+    if (
+      !toolRun ||
+      !result.ok ||
+      parseGitInspectAction(result.content) !== "issue_plan"
+    ) {
+      return null;
+    }
+
+    const issuePlan = extractIssuePlanFromGitInspectReport(result.content);
+
+    if (!issuePlan || deriveIssueInvestigationToolCallFromToolRun(toolRun)) {
+      return null;
+    }
+
+    return {
+      type: "immediate",
+      message: issuePlan,
+    };
+  },
 };

--- a/src/lib/tools/read-file.ts
+++ b/src/lib/tools/read-file.ts
@@ -6,6 +6,10 @@ import type {
   ToolResult,
 } from "@/lib/tools/types";
 import { resolveWorkspacePath } from "@/lib/tools/workspace-path";
+import {
+  formatIssueInvestigationAnswer,
+  isIssueDrivenReadForDraft,
+} from "@/lib/agent/issue-flow";
 
 const DEFAULT_MAX_LINES = 500;
 const MAX_LINES_LIMIT = 1000;
@@ -215,4 +219,14 @@ export const readFileTool: AgentTool = {
     additionalProperties: false,
   },
   execute: executeReadFile,
+  onResult(goal, _result, toolRuns) {
+    const issueInvestigationAnswer = formatIssueInvestigationAnswer(goal, toolRuns);
+
+    return issueInvestigationAnswer && !isIssueDrivenReadForDraft(toolRuns)
+      ? {
+          type: "immediate",
+          message: issueInvestigationAnswer,
+        }
+      : null;
+  },
 };

--- a/src/lib/tools/read-page.ts
+++ b/src/lib/tools/read-page.ts
@@ -6,6 +6,7 @@ import type {
 } from "@/lib/tools/types";
 import { launchPlaywrightChromium } from "@/lib/tools/playwright-browser";
 import { assertSafeUrl } from "@/lib/tools/url-guard";
+import { formatReadPageAnswer } from "@/lib/agent/page-result-format";
 
 const NAVIGATION_TIMEOUT_MS = 15_000;
 const MAX_TEXT_LENGTH = 2_000;
@@ -208,4 +209,21 @@ export const readPageTool: AgentTool = {
     additionalProperties: false,
   },
   execute: executeReadPage,
+  onResult(goal, result) {
+    if (!result.ok) {
+      return {
+        type: "immediate",
+        message: result.content,
+      };
+    }
+
+    const formattedReadPageAnswer = formatReadPageAnswer(goal, result.content);
+
+    return formattedReadPageAnswer
+      ? {
+          type: "immediate",
+          message: formattedReadPageAnswer,
+        }
+      : null;
+  },
 };

--- a/src/lib/tools/replace-text.ts
+++ b/src/lib/tools/replace-text.ts
@@ -230,4 +230,12 @@ export const replaceTextTool: AgentTool = {
     additionalProperties: false,
   },
   execute: executeReplaceText,
+  onResult(_goal, result) {
+    return result.draft
+      ? {
+          type: "immediate",
+          message: result.content,
+        }
+      : null;
+  },
 };

--- a/src/lib/tools/safe-command.ts
+++ b/src/lib/tools/safe-command.ts
@@ -88,6 +88,21 @@ function parseArgTags(text: string) {
     .filter((value) => value.length > 0);
 }
 
+function getStringArg(args: ToolCallArgs, key: string) {
+  const value = args[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function getStringArrayArg(args: ToolCallArgs, key: string) {
+  const value = args[key];
+
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === "string");
+}
+
 function normalizeRelativePath(targetPath: string) {
   return path.relative(getWorkspaceRoot(), targetPath).replace(/\\/g, "/") || ".";
 }
@@ -340,6 +355,25 @@ function parseSafeCommandInput(input: ToolExecutionInput) {
   return parseSafeCommandObjectInput(input);
 }
 
+function isVerificationSafeCommandInput(input: ToolExecutionInput) {
+  if (typeof input === "string") {
+    return false;
+  }
+
+  const command = getStringArg(input, "command").toLowerCase();
+  const args = getStringArrayArg(input, "args");
+
+  if (command === "git" && args.length === 1 && args[0] === "status") {
+    return true;
+  }
+
+  return (
+    command === "npm" &&
+    ((args.length === 2 && args[0] === "run" && args[1] === "build") ||
+      (args.length === 1 && args[0] === "test"))
+  );
+}
+
 async function executeSafeCommand(input: ToolExecutionInput): Promise<ToolResult> {
   const parsed = parseSafeCommandInput(input);
 
@@ -490,6 +524,18 @@ export const safeCommandTool: AgentTool = {
     additionalProperties: false,
   },
   execute: executeSafeCommand,
+  onResult(_goal, result, toolRuns) {
+    const toolRun = toolRuns.at(-1);
+
+    if (!toolRun || !isVerificationSafeCommandInput(toolRun.input)) {
+      return null;
+    }
+
+    return {
+      type: "immediate",
+      message: result.content,
+    };
+  },
 };
 
 export const __safeCommandTestInternals = {

--- a/src/lib/tools/search-text.ts
+++ b/src/lib/tools/search-text.ts
@@ -8,6 +8,10 @@ import type {
   ToolResult,
 } from "@/lib/tools/types";
 import { getWorkspaceRoot, resolveWorkspacePath } from "@/lib/tools/workspace-path";
+import {
+  formatIssueInvestigationAnswer,
+  isIssueDrivenReadForDraft,
+} from "@/lib/agent/issue-flow";
 
 const execFileAsync = promisify(execFile);
 const MAX_RESULTS = 50;
@@ -213,4 +217,14 @@ export const searchTextTool: AgentTool = {
     additionalProperties: false,
   },
   execute: executeSearchText,
+  onResult(goal, _result, toolRuns) {
+    const issueInvestigationAnswer = formatIssueInvestigationAnswer(goal, toolRuns);
+
+    return issueInvestigationAnswer && !isIssueDrivenReadForDraft(toolRuns)
+      ? {
+          type: "immediate",
+          message: issueInvestigationAnswer,
+        }
+      : null;
+  },
 };

--- a/src/lib/tools/types.ts
+++ b/src/lib/tools/types.ts
@@ -47,9 +47,26 @@ export type ToolInputSchema = {
 
 export type ToolExecutionInput = string | ToolCallArgs;
 
+export type ToolRun = {
+  input: ToolExecutionInput;
+  inputText: string;
+  name: string;
+  result: ToolResult;
+};
+
+export type ImmediateToolOutcome = {
+  message: string;
+  type: "immediate";
+};
+
 export type AgentTool = {
   description: string;
   inputSchema: ToolInputSchema;
   execute: (input: ToolExecutionInput) => Promise<ToolResult>;
   name: string;
+  onResult?: (
+    goal: string,
+    result: ToolResult,
+    toolRuns: ToolRun[],
+  ) => ImmediateToolOutcome | null;
 };

--- a/src/lib/tools/write-file.ts
+++ b/src/lib/tools/write-file.ts
@@ -157,4 +157,12 @@ export const writeFileTool: AgentTool = {
     additionalProperties: false,
   },
   execute: executeWriteFile,
+  onResult(_goal, result) {
+    return result.draft
+      ? {
+          type: "immediate",
+          message: result.content,
+        }
+      : null;
+  },
 };


### PR DESCRIPTION
﻿## What changed
- Split planner/thinking helpers out of `run-agent.ts` into `agent-thinking.ts`, reducing the main loop file to 539 lines.
- Added `AgentTool.onResult` so tools own their immediate-result behavior.
- Replaced direct tool shortcuts with an ordered rules table.
- Added provider-aware model client factory logic while keeping DeepSeek as the default provider.

## Validation
- `npx tsc --noEmit`
- `npm run lint`
- `npm test`
- `npm run build`
