### PR TITLE
[codex] Make agent tool call budget configurable

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -16,5 +16,8 @@ NEXT_PUBLIC_AGENT_API_SECRET=replace-with-the-same-local-secret
 # Leave empty to use data/workspace.
 # AGENT_WORKSPACE_ROOT=C:\path\to\project
 
+# Optional: maximum tool calls the agent may use for one request.
+# AGENT_MAX_TOOL_CALLS=8
+
 # Optional: set this only if GitHub CLI is not available on PATH.
 # GH_PATH=C:\path\to\gh.exe

--- a/src/lib/agent/tool-run-types.ts
+++ b/src/lib/agent/tool-run-types.ts
@@ -22,7 +22,18 @@ export type ToolRun = ToolRunBase & {
 
 export const APPROVE_WRITE_COMMAND = "APPROVE_WRITE";
 export const CANCEL_WRITE_COMMAND = "CANCEL_WRITE";
-export const MAX_TOOL_CALLS = 4;
+
+function readMaxToolCalls() {
+  const rawValue = process.env.AGENT_MAX_TOOL_CALLS?.trim();
+  if (!rawValue || !/^\d+$/.test(rawValue)) {
+    return 4;
+  }
+
+  const parsedValue = Number(rawValue);
+  return Number.isSafeInteger(parsedValue) && parsedValue > 0 ? parsedValue : 4;
+}
+
+export const MAX_TOOL_CALLS = readMaxToolCalls();
 
 export function createSyntheticToolCallId() {
   return `tool-call-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;


### PR DESCRIPTION
## Summary
- Read `AGENT_MAX_TOOL_CALLS` from the environment in `tool-run-types.ts`.
- Keep the default tool-call budget at 4 when the value is missing or invalid.
- Document the optional setting in `.env.local.example`.

## Validation
- `npm run build`
- `npm test`