### PR TITLE
[codex] Add polyglot safe_command allowlist

### DIFF
--- a/src/lib/tools/safe-command.ts
+++ b/src/lib/tools/safe-command.ts
@@ -32,7 +32,18 @@ const BLOCKED_COMMANDS = new Set([
   "wget",
 ]);
 
-type SafeExecutable = "git" | "npm" | "rg";
+type PackageManager = "npm" | "pnpm" | "yarn";
+type PackageScript = "build" | "lint" | "test";
+type SafeExecutable =
+  | "cargo"
+  | "git"
+  | "make"
+  | "npm"
+  | "pnpm"
+  | "pytest"
+  | "rg"
+  | "ruff"
+  | "yarn";
 
 type SafeCommandPlan =
   | {
@@ -46,7 +57,19 @@ type SafeCommandPlan =
       message: string;
     };
 
-const ALLOWED_COMMANDS = new Set<SafeExecutable>(["git", "npm", "rg"]);
+const ALLOWED_COMMANDS = new Set<SafeExecutable>([
+  "cargo",
+  "git",
+  "make",
+  "npm",
+  "pnpm",
+  "pytest",
+  "rg",
+  "ruff",
+  "yarn",
+]);
+const PACKAGE_SCRIPTS = new Set<PackageScript>(["build", "lint", "test"]);
+const PACKAGE_MANAGERS = new Set<PackageManager>(["npm", "pnpm", "yarn"]);
 
 type SafeCommandStatus = "success" | "failed" | "rejected";
 
@@ -63,10 +86,13 @@ function resolveRuntimeCommand(
   executable: SafeExecutable,
   executableArgs: string[],
 ) {
-  if (process.platform === "win32" && executable === "npm") {
+  if (
+    process.platform === "win32" &&
+    (executable === "npm" || executable === "pnpm" || executable === "yarn")
+  ) {
     return {
       executable: "cmd.exe",
-      executableArgs: ["/d", "/c", "npm.cmd", ...executableArgs],
+      executableArgs: ["/d", "/c", `${executable}.cmd`, ...executableArgs],
     };
   }
 
@@ -263,7 +289,27 @@ function buildAllowedGitCall(args: string[]): SafeCommandPlan {
   };
 }
 
-function workspaceHasNpmScript(scriptName: string) {
+function workspaceHasFile(fileName: string) {
+  return existsSync(path.join(getWorkspaceRoot(), fileName));
+}
+
+function detectPackageManager(): PackageManager | null {
+  if (workspaceHasFile("pnpm-lock.yaml")) {
+    return "pnpm";
+  }
+
+  if (workspaceHasFile("yarn.lock")) {
+    return "yarn";
+  }
+
+  if (workspaceHasFile("package-lock.json") || workspaceHasFile("package.json")) {
+    return "npm";
+  }
+
+  return null;
+}
+
+function workspaceHasPackageScript(scriptName: string) {
   const packageJsonPath = path.join(getWorkspaceRoot(), "package.json");
 
   if (!existsSync(packageJsonPath)) {
@@ -281,54 +327,160 @@ function workspaceHasNpmScript(scriptName: string) {
   }
 }
 
-function buildAllowedNpmCall(args: string[]): SafeCommandPlan {
-  if (args.length === 2 && args[0] === "run" && args[1] === "build") {
+function isPackageManager(command: SafeExecutable): command is PackageManager {
+  return PACKAGE_MANAGERS.has(command as PackageManager);
+}
+
+function getPackageScriptFromArgs(command: PackageManager, args: string[]) {
+  if (args.length === 2 && args[0] === "run") {
+    return PACKAGE_SCRIPTS.has(args[1] as PackageScript)
+      ? (args[1] as PackageScript)
+      : null;
+  }
+
+  if (command === "npm" && args.length === 1 && args[0] === "test") {
+    return "test";
+  }
+
+  if (command !== "npm" && args.length === 1) {
+    return PACKAGE_SCRIPTS.has(args[0] as PackageScript)
+      ? (args[0] as PackageScript)
+      : null;
+  }
+
+  return null;
+}
+
+function buildAllowedPackageManagerCall(
+  command: PackageManager,
+  args: string[],
+): SafeCommandPlan {
+  const packageManager = detectPackageManager();
+  const scriptName = getPackageScriptFromArgs(command, args);
+
+  if (!packageManager) {
     return {
-      ok: true,
-      commandText: "npm run build",
-      executable: "npm",
-      executableArgs: ["run", "build"],
+      ok: false,
+      message:
+        "safe_command did not find package.json or a JavaScript lockfile in this workspace, so package manager commands are not allowed.",
     };
   }
 
-  if (args.length === 2 && args[0] === "run" && args[1] === "lint") {
-    if (!workspaceHasNpmScript("lint")) {
-      return {
-        ok: false,
-        message:
-          'safe_command checked package.json and did not find a "lint" script, so npm run lint is not allowed in this workspace.',
-      };
-    }
-
+  if (command !== packageManager) {
     return {
-      ok: true,
-      commandText: "npm run lint",
-      executable: "npm",
-      executableArgs: ["run", "lint"],
+      ok: false,
+      message: `safe_command detected ${packageManager} for this workspace, so ${command} commands are not allowed here.`,
     };
   }
 
-  if (args.length === 1 && args[0] === "test") {
-    if (!workspaceHasNpmScript("test")) {
-      return {
-        ok: false,
-        message:
-          'safe_command checked package.json and did not find a "test" script, so npm test is not allowed in this workspace.',
-      };
-    }
+  if (!scriptName) {
+    return {
+      ok: false,
+      message:
+        "safe_command allows only build, test, or lint package scripts for the detected package manager.",
+    };
+  }
 
+  if (!workspaceHasPackageScript(scriptName)) {
+    return {
+      ok: false,
+      message: `safe_command checked package.json and did not find a "${scriptName}" script, so ${command} ${args.join(" ")} is not allowed in this workspace.`,
+    };
+  }
+
+  return {
+    ok: true,
+    commandText: `${command} ${args.join(" ")}`,
+    executable: command,
+    executableArgs: args,
+  };
+}
+
+function buildAllowedCargoCall(args: string[]): SafeCommandPlan {
+  if (!workspaceHasFile("Cargo.toml")) {
+    return {
+      ok: false,
+      message:
+        "safe_command did not find Cargo.toml in this workspace, so cargo commands are not allowed.",
+    };
+  }
+
+  if (args.length === 1 && ["build", "test", "clippy"].includes(args[0])) {
     return {
       ok: true,
-      commandText: "npm test",
-      executable: "npm",
-      executableArgs: ["test"],
+      commandText: `cargo ${args[0]}`,
+      executable: "cargo",
+      executableArgs: args,
     };
   }
 
   return {
     ok: false,
-    message:
-      'safe_command currently allows only npm run build, npm run lint when package.json includes a lint script, or npm test when package.json includes a test script.',
+    message: "safe_command allows only cargo build, cargo test, or cargo clippy.",
+  };
+}
+
+function buildAllowedPythonToolCall(
+  command: "pytest" | "ruff",
+  args: string[],
+): SafeCommandPlan {
+  if (!workspaceHasFile("pyproject.toml") && !workspaceHasFile("setup.py")) {
+    return {
+      ok: false,
+      message:
+        "safe_command did not find pyproject.toml or setup.py in this workspace, so Python tool commands are not allowed.",
+    };
+  }
+
+  if (command === "pytest" && args.length === 0) {
+    return {
+      ok: true,
+      commandText: "pytest",
+      executable: "pytest",
+      executableArgs: [],
+    };
+  }
+
+  if (
+    command === "ruff" &&
+    args.length === 1 &&
+    (args[0] === "check" || args[0] === "format")
+  ) {
+    return {
+      ok: true,
+      commandText: `ruff ${args[0]}`,
+      executable: "ruff",
+      executableArgs: args,
+    };
+  }
+
+  return {
+    ok: false,
+    message: "safe_command allows only pytest, ruff check, or ruff format.",
+  };
+}
+
+function buildAllowedMakeCall(args: string[]): SafeCommandPlan {
+  if (!workspaceHasFile("Makefile")) {
+    return {
+      ok: false,
+      message:
+        "safe_command did not find Makefile in this workspace, so make commands are not allowed.",
+    };
+  }
+
+  if (args.length === 1 && ["build", "test", "lint"].includes(args[0])) {
+    return {
+      ok: true,
+      commandText: `make ${args[0]}`,
+      executable: "make",
+      executableArgs: args,
+    };
+  }
+
+  return {
+    ok: false,
+    message: "safe_command allows only make build, make test, or make lint.",
   };
 }
 
@@ -344,7 +496,19 @@ function buildAllowedCommandCall(
     return buildAllowedGitCall(args);
   }
 
-  return buildAllowedNpmCall(args);
+  if (isPackageManager(command)) {
+    return buildAllowedPackageManagerCall(command, args);
+  }
+
+  if (command === "cargo") {
+    return buildAllowedCargoCall(args);
+  }
+
+  if (command === "pytest" || command === "ruff") {
+    return buildAllowedPythonToolCall(command, args);
+  }
+
+  return buildAllowedMakeCall(args);
 }
 
 function parseSafeCommandInput(input: ToolExecutionInput) {
@@ -367,11 +531,9 @@ function isVerificationSafeCommandInput(input: ToolExecutionInput) {
     return true;
   }
 
-  return (
-    command === "npm" &&
-    ((args.length === 2 && args[0] === "run" && args[1] === "build") ||
-      (args.length === 1 && args[0] === "test"))
-  );
+  return PACKAGE_MANAGERS.has(command as PackageManager)
+    ? getPackageScriptFromArgs(command as PackageManager, args) !== null
+    : false;
 }
 
 async function executeSafeCommand(input: ToolExecutionInput): Promise<ToolResult> {
@@ -503,14 +665,14 @@ async function executeSafeCommand(input: ToolExecutionInput): Promise<ToolResult
 export const safeCommandTool: AgentTool = {
   name: "safe_command",
   description:
-    "Run one whitelisted local command inside the current workspace. MVP allowlist: rg search, rg --files, git status, npm run build, npm run lint only when package.json includes a lint script, and npm test only when package.json includes a test script.",
+    "Run one whitelisted local command inside the current workspace. Allowlist: rg search, rg --files, git status, detected npm/pnpm/yarn build/test/lint scripts, cargo build/test/clippy, pytest, ruff check/format, and make build/test/lint.",
   inputSchema: {
     type: "object",
     properties: {
       command: {
         type: "string",
         description:
-          'Required allowed command name. Current MVP allowlist: "rg", "git", or "npm".',
+          'Required allowed command name. Allowlist: "rg", "git", "npm", "pnpm", "yarn", "cargo", "pytest", "ruff", or "make".',
       },
       args: {
         type: "array",

--- a/test/safe-command.test.ts
+++ b/test/safe-command.test.ts
@@ -7,6 +7,20 @@ import { __safeCommandTestInternals, safeCommandTool } from "../src/lib/tools/sa
 
 const { buildAllowedCommandCall } = __safeCommandTestInternals;
 
+function createWorkspace(files: Record<string, string>) {
+  const workspaceRoot = mkdtempSync(path.join(tmpdir(), "thrush-safe-command-"));
+
+  for (const [fileName, content] of Object.entries(files)) {
+    writeFileSync(path.join(workspaceRoot, fileName), content);
+  }
+
+  return workspaceRoot;
+}
+
+function packageJson(scripts: Record<string, string>) {
+  return JSON.stringify({ scripts });
+}
+
 function withWorkspaceRoot<T>(workspaceRoot: string, callback: () => T): T {
   const previousRoot = process.env.AGENT_WORKSPACE_ROOT;
   process.env.AGENT_WORKSPACE_ROOT = workspaceRoot;
@@ -33,23 +47,99 @@ test("safe_command allows the MVP command allowlist", () => {
   });
 });
 
-test("safe_command rejects npm run lint when the workspace has no lint script", () => {
-  const workspaceRoot = mkdtempSync(path.join(tmpdir(), "thrush-safe-command-"));
-  writeFileSync(
-    path.join(workspaceRoot, "package.json"),
-    JSON.stringify({ scripts: { test: "node --test" } }),
-  );
+test("safe_command detects pnpm and yarn lockfiles", () => {
+  const scripts = packageJson({
+    build: "echo build",
+    lint: "echo lint",
+    test: "echo test",
+  });
+
+  withWorkspaceRoot(createWorkspace({ "package.json": scripts, "pnpm-lock.yaml": "" }), () => {
+    assert.equal(buildAllowedCommandCall("pnpm", ["build"]).ok, true);
+    assert.equal(buildAllowedCommandCall("pnpm", ["test"]).ok, true);
+    assert.equal(buildAllowedCommandCall("pnpm", ["lint"]).ok, true);
+    assert.equal(buildAllowedCommandCall("npm", ["run", "build"]).ok, false);
+  });
+
+  withWorkspaceRoot(createWorkspace({ "package.json": scripts, "yarn.lock": "" }), () => {
+    assert.equal(buildAllowedCommandCall("yarn", ["build"]).ok, true);
+    assert.equal(buildAllowedCommandCall("yarn", ["test"]).ok, true);
+    assert.equal(buildAllowedCommandCall("yarn", ["lint"]).ok, true);
+    assert.equal(buildAllowedCommandCall("npm", ["run", "build"]).ok, false);
+  });
+});
+
+test("safe_command defaults JavaScript workspaces without lockfiles to npm", () => {
+  const workspaceRoot = createWorkspace({
+    "package.json": packageJson({
+      build: "echo build",
+      lint: "echo lint",
+      test: "echo test",
+    }),
+  });
 
   withWorkspaceRoot(workspaceRoot, () => {
-    const result = buildAllowedCommandCall("npm", ["run", "lint"]);
+    assert.equal(buildAllowedCommandCall("npm", ["run", "build"]).ok, true);
+    assert.equal(buildAllowedCommandCall("npm", ["test"]).ok, true);
+    assert.equal(buildAllowedCommandCall("npm", ["run", "lint"]).ok, true);
+    assert.equal(buildAllowedCommandCall("pnpm", ["build"]).ok, false);
+  });
+});
 
-    assert.equal(result.ok, false);
-    assert.match(result.message, /did not find a "lint" script/);
+test("safe_command rejects package scripts missing from package.json", () => {
+  const workspaceRoot = createWorkspace({
+    "package.json": packageJson({ test: "node --test" }),
+  });
+
+  withWorkspaceRoot(workspaceRoot, () => {
+    const buildResult = buildAllowedCommandCall("npm", ["run", "build"]);
+    const lintResult = buildAllowedCommandCall("npm", ["run", "lint"]);
+
+    assert.equal(buildResult.ok, false);
+    assert.match(buildResult.message, /did not find a "build" script/);
+    assert.equal(lintResult.ok, false);
+    assert.match(lintResult.message, /did not find a "lint" script/);
+  });
+});
+
+test("safe_command allows cargo build, test, and clippy in Rust workspaces", () => {
+  const workspaceRoot = createWorkspace({ "Cargo.toml": "[package]\nname = \"demo\"\n" });
+
+  withWorkspaceRoot(workspaceRoot, () => {
+    assert.equal(buildAllowedCommandCall("cargo", ["build"]).ok, true);
+    assert.equal(buildAllowedCommandCall("cargo", ["test"]).ok, true);
+    assert.equal(buildAllowedCommandCall("cargo", ["clippy"]).ok, true);
+    assert.equal(buildAllowedCommandCall("cargo", ["run"]).ok, false);
+  });
+});
+
+test("safe_command allows pytest and ruff in Python workspaces", () => {
+  withWorkspaceRoot(createWorkspace({ "pyproject.toml": "[project]\nname = \"demo\"\n" }), () => {
+    assert.equal(buildAllowedCommandCall("pytest", []).ok, true);
+    assert.equal(buildAllowedCommandCall("ruff", ["check"]).ok, true);
+    assert.equal(buildAllowedCommandCall("ruff", ["format"]).ok, true);
+    assert.equal(buildAllowedCommandCall("ruff", ["check", "."]).ok, false);
+  });
+
+  withWorkspaceRoot(createWorkspace({ "setup.py": "from setuptools import setup\n" }), () => {
+    assert.equal(buildAllowedCommandCall("pytest", []).ok, true);
+    assert.equal(buildAllowedCommandCall("ruff", ["check"]).ok, true);
+  });
+});
+
+test("safe_command allows make build, test, and lint when Makefile exists", () => {
+  const workspaceRoot = createWorkspace({ Makefile: "build:\n\ttest -n build\n" });
+
+  withWorkspaceRoot(workspaceRoot, () => {
+    assert.equal(buildAllowedCommandCall("make", ["build"]).ok, true);
+    assert.equal(buildAllowedCommandCall("make", ["test"]).ok, true);
+    assert.equal(buildAllowedCommandCall("make", ["lint"]).ok, true);
+    assert.equal(buildAllowedCommandCall("make", ["install"]).ok, false);
   });
 });
 
 test("safe_command rejects commands outside the allowlist", async () => {
-  const blockedShell = await safeCommandTool.execute({
+  const blockedPowerShell = await safeCommandTool.execute({
     command: "powershell",
     args: ["Get-ChildItem"],
   });
@@ -57,13 +147,31 @@ test("safe_command rejects commands outside the allowlist", async () => {
     command: "ls",
     args: [],
   });
+  const blockedPython = await safeCommandTool.execute({
+    command: "python",
+    args: ["-m", "pytest"],
+  });
+  const blockedNode = await safeCommandTool.execute({
+    command: "node",
+    args: ["script.js"],
+  });
+  const blockedBash = await safeCommandTool.execute({
+    command: "bash",
+    args: ["-lc", "echo unsafe"],
+  });
   const customRgFlag = buildAllowedCommandCall("rg", ["--hidden"]);
   const unsupportedNpmScript = buildAllowedCommandCall("npm", ["run", "dev"]);
 
-  assert.equal(blockedShell.ok, false);
-  assert.match(blockedShell.content, /blocked for safety/);
+  assert.equal(blockedPowerShell.ok, false);
+  assert.match(blockedPowerShell.content, /blocked for safety/);
   assert.equal(unknownCommand.ok, false);
   assert.match(unknownCommand.content, /not in the safe_command allowlist/);
+  assert.equal(blockedPython.ok, false);
+  assert.match(blockedPython.content, /blocked for safety/);
+  assert.equal(blockedNode.ok, false);
+  assert.match(blockedNode.content, /blocked for safety/);
+  assert.equal(blockedBash.ok, false);
+  assert.match(blockedBash.content, /blocked for safety/);
   assert.equal(customRgFlag.ok, false);
   assert.equal(unsupportedNpmScript.ok, false);
 });


### PR DESCRIPTION
## Summary

- Detect the current workspace on every safe_command execution and select npm, pnpm, or yarn from lockfiles/package.json.
- Add exact allowlist support for Rust, Python tooling, and Makefile workflows without allowing shell, node, or python entrypoints.
- Expand safe_command tests for lockfile detection, missing scripts, cargo, pytest/ruff, make, and blocked command boundaries.

## Validation

- npm run build
- npm test