### PR TITLE
[codex] Add SQLite migration system

### DIFF
--- a/src/lib/db/connection.ts
+++ b/src/lib/db/connection.ts
@@ -1,85 +1,12 @@
 import Database from "better-sqlite3";
 import { mkdirSync } from "node:fs";
 import path from "node:path";
+import { migrate } from "@/lib/db/migrate";
 
 let db: Database.Database | null = null;
 
 function getDatabasePath() {
   return path.resolve(process.cwd(), "data", "thrush.db");
-}
-
-function applySchema(database: Database.Database) {
-  database.exec(`
-    PRAGMA foreign_keys = ON;
-
-    CREATE TABLE IF NOT EXISTS projects (
-      id TEXT PRIMARY KEY,
-      name TEXT NOT NULL,
-      workspace_path TEXT NOT NULL UNIQUE,
-      workspace_path_confirmed_at INTEGER,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS sessions (
-      id TEXT PRIMARY KEY,
-      project_id TEXT NOT NULL,
-      title TEXT NOT NULL,
-      status TEXT NOT NULL DEFAULT 'active',
-      context_json TEXT NOT NULL DEFAULT '{}',
-      steps_json TEXT NOT NULL DEFAULT '[]',
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL,
-      FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
-    );
-
-    CREATE TABLE IF NOT EXISTS messages (
-      id TEXT PRIMARY KEY,
-      session_id TEXT NOT NULL,
-      role TEXT NOT NULL CHECK (role IN ('user', 'assistant')),
-      content TEXT NOT NULL,
-      reasoning_content TEXT,
-      created_at INTEGER NOT NULL,
-      FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
-    );
-
-    CREATE TABLE IF NOT EXISTS tool_runs (
-      id TEXT PRIMARY KEY,
-      session_id TEXT NOT NULL,
-      request_id TEXT NOT NULL,
-      tool_call_id TEXT NOT NULL,
-      tool_name TEXT NOT NULL,
-      input_json TEXT NOT NULL,
-      input_text TEXT NOT NULL,
-      ok INTEGER NOT NULL,
-      result_content TEXT NOT NULL,
-      draft_json TEXT,
-      started_at INTEGER NOT NULL,
-      finished_at INTEGER NOT NULL,
-      duration_ms INTEGER NOT NULL,
-      FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
-    );
-
-    CREATE TABLE IF NOT EXISTS checkpoints (
-      id TEXT PRIMARY KEY,
-      session_id TEXT NOT NULL,
-      request_id TEXT NOT NULL,
-      kind TEXT NOT NULL,
-      label TEXT,
-      data_json TEXT NOT NULL,
-      created_at INTEGER NOT NULL,
-      FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_sessions_project_updated
-      ON sessions(project_id, updated_at);
-    CREATE INDEX IF NOT EXISTS idx_messages_session_created
-      ON messages(session_id, created_at);
-    CREATE INDEX IF NOT EXISTS idx_tool_runs_session_finished
-      ON tool_runs(session_id, finished_at);
-    CREATE INDEX IF NOT EXISTS idx_checkpoints_session_created
-      ON checkpoints(session_id, created_at);
-  `);
 }
 
 export function getDb() {
@@ -91,7 +18,8 @@ export function getDb() {
   mkdirSync(path.dirname(databasePath), { recursive: true });
 
   db = new Database(databasePath);
-  applySchema(db);
+  db.pragma("foreign_keys = ON");
+  migrate(db);
 
   return db;
 }

--- a/src/lib/db/migrate.ts
+++ b/src/lib/db/migrate.ts
@@ -1,0 +1,63 @@
+import type Database from "better-sqlite3";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const MIGRATIONS_TABLE = "_migrations";
+
+function getMigrationsDir() {
+  return path.resolve(process.cwd(), "src", "lib", "db", "migrations");
+}
+
+function ensureMigrationsTable(database: Database.Database) {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS ${MIGRATIONS_TABLE} (
+      filename TEXT PRIMARY KEY,
+      executed_at INTEGER NOT NULL
+    );
+  `);
+}
+
+function listMigrationFiles() {
+  const migrationsDir = getMigrationsDir();
+
+  if (!existsSync(migrationsDir)) {
+    return [];
+  }
+
+  return readdirSync(migrationsDir)
+    .filter((filename) => /^\d+_.+\.sql$/.test(filename))
+    .sort((first, second) => first.localeCompare(second));
+}
+
+function getExecutedMigrations(database: Database.Database) {
+  const rows = database
+    .prepare(`SELECT filename FROM ${MIGRATIONS_TABLE}`)
+    .all() as Array<{ filename: string }>;
+
+  return new Set(rows.map((row) => row.filename));
+}
+
+export function migrate(database: Database.Database) {
+  ensureMigrationsTable(database);
+
+  const migrationsDir = getMigrationsDir();
+  const executedMigrations = getExecutedMigrations(database);
+  const pendingMigrations = listMigrationFiles().filter(
+    (filename) => !executedMigrations.has(filename),
+  );
+
+  for (const filename of pendingMigrations) {
+    const sql = readFileSync(path.join(migrationsDir, filename), "utf8");
+
+    const runMigration = database.transaction(() => {
+      database.exec(sql);
+      database
+        .prepare(
+          `INSERT INTO ${MIGRATIONS_TABLE} (filename, executed_at) VALUES (?, ?)`,
+        )
+        .run(filename, Date.now());
+    });
+
+    runMigration();
+  }
+}

--- a/src/lib/db/migrations/001_init.sql
+++ b/src/lib/db/migrations/001_init.sql
@@ -1,0 +1,67 @@
+CREATE TABLE IF NOT EXISTS projects (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  workspace_path TEXT NOT NULL UNIQUE,
+  workspace_path_confirmed_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  context_json TEXT NOT NULL DEFAULT '{}',
+  steps_json TEXT NOT NULL DEFAULT '[]',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  role TEXT NOT NULL CHECK (role IN ('user', 'assistant')),
+  content TEXT NOT NULL,
+  reasoning_content TEXT,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS tool_runs (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  request_id TEXT NOT NULL,
+  tool_call_id TEXT NOT NULL,
+  tool_name TEXT NOT NULL,
+  input_json TEXT NOT NULL,
+  input_text TEXT NOT NULL,
+  ok INTEGER NOT NULL,
+  result_content TEXT NOT NULL,
+  draft_json TEXT,
+  started_at INTEGER NOT NULL,
+  finished_at INTEGER NOT NULL,
+  duration_ms INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS checkpoints (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  request_id TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  label TEXT,
+  data_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_project_updated
+  ON sessions(project_id, updated_at);
+CREATE INDEX IF NOT EXISTS idx_messages_session_created
+  ON messages(session_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_tool_runs_session_finished
+  ON tool_runs(session_id, finished_at);
+CREATE INDEX IF NOT EXISTS idx_checkpoints_session_created
+  ON checkpoints(session_id, created_at);


### PR DESCRIPTION
﻿## What changed
- Added `src/lib/db/migrations/001_init.sql` with the existing SQLite schema.
- Added `src/lib/db/migrate.ts` to track and run pending migration files through `_migrations`.
- Updated database initialization to enable foreign keys and run migrations automatically.

## Why
Thrush previously relied on `CREATE TABLE IF NOT EXISTS` during startup with no schema version history. Future database changes can now be added as numbered SQL files such as `002_xxx.sql` without changing the connection setup.

## Validation
- `npm run build`
- `npm test`
- Smoke-tested `001_init.sql` against a temporary SQLite database.
