### PR TITLE
[codex] Add session auto approve

### DIFF
--- a/src/app/api/projects/[projectId]/sessions/route.ts
+++ b/src/app/api/projects/[projectId]/sessions/route.ts
@@ -8,7 +8,7 @@ export async function POST(
   context: { params: Promise<{ projectId: string }> },
 ) {
   const { projectId } = await context.params;
-  let body: { title?: unknown } = {};
+  let body: { autoApprove?: unknown; title?: unknown } = {};
 
   try {
     body = await request.json();
@@ -22,6 +22,9 @@ export async function POST(
       typeof body.title === "string" && body.title.trim()
         ? body.title.trim()
         : "New session",
+      {
+        autoApprove: body.autoApprove === true,
+      },
     );
 
     return NextResponse.json({

--- a/src/lib/agent/conversation-context.ts
+++ b/src/lib/agent/conversation-context.ts
@@ -41,6 +41,7 @@ export function normalizeSessionContext(
   }
 
   return {
+    autoApprove: sessionContext.autoApprove === true,
     conversationSummary: sessionContext.conversationSummary?.trim() || null,
     lastListedDirectoryPath: sessionContext.lastListedDirectoryPath?.trim() || null,
     lastReadFilePath: sessionContext.lastReadFilePath?.trim() || null,

--- a/src/lib/agent/draft-lifecycle.ts
+++ b/src/lib/agent/draft-lifecycle.ts
@@ -1,4 +1,4 @@
-import type { AgentResponse } from "@/types/agent";
+import type { AgentResponse, AgentSessionContext } from "@/types/agent";
 import type { WriteFileDraft } from "@/lib/tools/types";
 import { applyPendingWriteDraft } from "@/lib/tools/pending-write";
 import {
@@ -84,6 +84,36 @@ export function isAmbiguousDraftConfirmation(task: string) {
     /^(ok|okay|yes|yep|go ahead|looks good|approved?)$/.test(trimmedTask) ||
     /^(通过|好|行|可以|确认|没问题)$/.test(task.trim())
   );
+}
+
+export async function handleAutoWriteApproval(
+  sessionContext: AgentSessionContext,
+  pendingDraft: WriteFileDraft | null,
+): Promise<AgentResponse | null> {
+  if (
+    sessionContext.autoApprove !== true ||
+    sessionContext.readOnly === true ||
+    !pendingDraft
+  ) {
+    return null;
+  }
+
+  const approvalResult = await handleWriteApproval(
+    `${APPROVE_WRITE_COMMAND} ${pendingDraft.id}`,
+    pendingDraft,
+  );
+
+  if (!approvalResult) {
+    throw new Error("Expected an automatic pending draft approval result.");
+  }
+
+  return {
+    ...approvalResult,
+    sessionContext: {
+      ...sessionContext,
+      ...approvalResult.sessionContext,
+    },
+  };
 }
 
 export async function handleWriteApproval(

--- a/src/lib/agent/run-agent.ts
+++ b/src/lib/agent/run-agent.ts
@@ -29,6 +29,7 @@ import {
 } from "@/lib/agent/tool-run-types";
 import { buildNextSessionContext } from "@/lib/agent/session-state";
 import {
+  handleAutoWriteApproval,
   handleWriteApproval,
   isAmbiguousDraftConfirmation,
   parseDraftLifecycleAction,
@@ -110,6 +111,7 @@ export async function runAgent(
   const normalizedSessionContext = normalizeSessionContext(sessionContext);
   const effectiveSessionContext: AgentSessionContext = {
     ...normalizedSessionContext,
+    autoApprove: normalizedSessionContext.autoApprove === true,
     pendingDraft: normalizedSessionContext.pendingDraft ?? null,
     projectId: options.projectId ?? normalizedSessionContext.projectId ?? null,
     readOnly: normalizedSessionContext.readOnly === true,
@@ -148,6 +150,17 @@ export async function runAgent(
       true,
       0,
     );
+  }
+
+  if (!draftLifecycleAction) {
+    const autoApprovalResult = await handleAutoWriteApproval(
+      effectiveSessionContext,
+      effectiveSessionContext.pendingDraft ?? null,
+    );
+
+    if (autoApprovalResult) {
+      return finishWithLogging(autoApprovalResult, true, 0);
+    }
   }
 
   if (draftLifecycleAction && !effectiveSessionContext.pendingDraft) {
@@ -491,6 +504,19 @@ export async function runAgent(
       toolRuns,
     );
     if (immediateOutcome?.type === "immediate") {
+      const nextSessionContext = buildNextSessionContext(
+        context.sessionContext,
+        toolRuns,
+      );
+      const autoApprovalResult = await handleAutoWriteApproval(
+        nextSessionContext,
+        toolRun.result.draft ?? null,
+      );
+
+      if (autoApprovalResult) {
+        return finishWithLogging(autoApprovalResult, true, toolRuns.length);
+      }
+
       await replaceLastStep(
         createStep(
           `act-${roundNumber}`,
@@ -502,7 +528,7 @@ export async function runAgent(
       return finishWithLogging(
         {
           message: createMessage(immediateOutcome.message),
-          sessionContext: buildNextSessionContext(context.sessionContext, toolRuns),
+          sessionContext: nextSessionContext,
           steps,
         },
         false,

--- a/src/lib/db/migrations/002_add_auto_approve.sql
+++ b/src/lib/db/migrations/002_add_auto_approve.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sessions
+  ADD COLUMN auto_approve INTEGER NOT NULL DEFAULT 0;

--- a/src/lib/db/store.ts
+++ b/src/lib/db/store.ts
@@ -27,6 +27,7 @@ type ProjectRow = {
 };
 
 type SessionRow = {
+  auto_approve: number;
   context_json: string;
   created_at: number;
   id: string;
@@ -71,6 +72,7 @@ function parseJson<T>(raw: string, fallback: T): T {
 
 function mapSessionSummary(row: SessionRow): SessionSummary {
   return {
+    auto_approve: row.auto_approve,
     createdAt: row.created_at,
     id: row.id,
     projectId: row.project_id,
@@ -94,7 +96,7 @@ function mapProjectSummary(row: ProjectRow, sessions: SessionSummary[]): Project
 function listSessionRowsForProject(projectId: string) {
   return getDb()
     .prepare(
-      `SELECT id, project_id, title, context_json, steps_json, created_at, updated_at
+      `SELECT id, project_id, title, auto_approve, context_json, steps_json, created_at, updated_at
        FROM sessions
        WHERE project_id = ?
        ORDER BY updated_at DESC`,
@@ -128,7 +130,11 @@ export function createProject(input: {
   return getProject(projectId);
 }
 
-export function createSession(projectId: string, title = "New session") {
+export function createSession(
+  projectId: string,
+  title = "New session",
+  options: { autoApprove?: boolean } = {},
+) {
   const db = getDb();
   const project = getProject(projectId);
 
@@ -139,18 +145,20 @@ export function createSession(projectId: string, title = "New session") {
   const timestamp = now();
   const sessionId = createId("sess");
   const context: AgentSessionContext = {
+    autoApprove: options.autoApprove === true,
     projectId,
     sessionId,
   };
 
   db.prepare(
     `INSERT INTO sessions
-      (id, project_id, title, context_json, steps_json, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      (id, project_id, title, auto_approve, context_json, steps_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     sessionId,
     projectId,
     title,
+    options.autoApprove === true ? 1 : 0,
     JSON.stringify(context),
     JSON.stringify(starterSteps),
     timestamp,
@@ -202,7 +210,7 @@ export function updateSessionState(
   getDb()
     .prepare(
       `UPDATE sessions
-       SET context_json = ?, steps_json = ?, updated_at = ?
+       SET context_json = ?, steps_json = ?, auto_approve = ?, updated_at = ?
        WHERE id = ?`,
     )
     .run(
@@ -211,6 +219,7 @@ export function updateSessionState(
         sessionId,
       }),
       JSON.stringify(steps),
+      sessionContext.autoApprove === true ? 1 : 0,
       timestamp,
       sessionId,
     );
@@ -241,7 +250,7 @@ export function getProject(projectId: string) {
 export function getSession(sessionId: string): SessionDetail | null {
   const row = getDb()
     .prepare(
-      `SELECT id, project_id, title, context_json, steps_json, created_at, updated_at
+      `SELECT id, project_id, title, auto_approve, context_json, steps_json, created_at, updated_at
        FROM sessions
        WHERE id = ?`,
     )
@@ -274,6 +283,7 @@ export function getSession(sessionId: string): SessionDetail | null {
     })),
     sessionContext: {
       ...sessionContext,
+      autoApprove: row.auto_approve === 1,
       projectId: row.project_id,
       sessionId: row.id,
     },

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -23,6 +23,7 @@ export type PendingWorkspaceSwitch = {
 };
 
 export type AgentSessionContext = {
+  autoApprove?: boolean;
   conversationSummary?: string | null;
   lastListedDirectoryPath?: string | null;
   lastReadFilePath?: string | null;

--- a/src/types/workbench.ts
+++ b/src/types/workbench.ts
@@ -15,6 +15,7 @@ export type ProjectSummary = {
 };
 
 export type SessionSummary = {
+  auto_approve: number;
   createdAt: number;
   id: string;
   projectId: string;


### PR DESCRIPTION
﻿## What changed
- Added `002_add_auto_approve.sql` to add `sessions.auto_approve` with `NOT NULL DEFAULT 0`.
- Added `autoApprove` to the session context and persisted it through session state updates.
- Updated session creation to accept `autoApprove` and session reads to return `auto_approve`.
- Added automatic draft approval that reuses the existing manual approval path.

## Safety
- `readOnly` still wins over `autoApprove`; read-only sessions do not write pending drafts.
- `autoApprove` only applies to pending write drafts and does not change command execution rules.
- Default is false, so existing session behavior stays unchanged.

## Validation
- `npm run build`
- `npm test`
- Smoke-tested migrations `001_init.sql` + `002_add_auto_approve.sql` against a temporary SQLite database.
