### PR TITLE
[codex] Add agent auto loop completion checks

### DIFF
--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -109,6 +109,7 @@ export async function POST(request: Request) {
   const messagesForAgent = [...session.messages, userMessage];
   const sessionContext = {
     ...session.sessionContext,
+    ...body.sessionContext,
     projectId: project.id,
     sessionId,
   };

--- a/src/lib/agent/agent-thinking.ts
+++ b/src/lib/agent/agent-thinking.ts
@@ -26,7 +26,7 @@ import {
   formatToolRunsForModel,
 } from "@/lib/agent/tool-args";
 import {
-  MAX_TOOL_CALLS,
+  getEffectiveMaxToolCalls,
   type ToolRun,
 } from "@/lib/agent/tool-run-types";
 import { formatSessionContextForModel } from "@/lib/agent/session-state";
@@ -85,8 +85,8 @@ type ThinkStrategy = {
   think: (context: ThinkStrategyContext) => Promise<ThoughtResult> | ThoughtResult;
 };
 
-function getRemainingToolCalls(toolRuns: ToolRun[]) {
-  return Math.max(MAX_TOOL_CALLS - toolRuns.length, 0);
+function getRemainingToolCalls(context: AgentContext, toolRuns: ToolRun[]) {
+  return Math.max(getEffectiveMaxToolCalls(context.sessionContext) - toolRuns.length, 0);
 }
 
 function buildThoughtPlan(toolRuns: ToolRun[], remainingToolCalls: number) {
@@ -274,7 +274,8 @@ export async function think(
   const readOnly = context.sessionContext.readOnly === true;
   const availableTools = listTools({ readOnly });
   const roundNumber = toolRuns.length + 1;
-  const remainingToolCalls = getRemainingToolCalls(toolRuns);
+  const maxToolCalls = getEffectiveMaxToolCalls(context.sessionContext);
+  const remainingToolCalls = getRemainingToolCalls(context, toolRuns);
   const plan = buildThoughtPlan(toolRuns, remainingToolCalls);
 
   const toolList = availableTools
@@ -311,6 +312,7 @@ export async function think(
         {
           role: "system",
           content: buildPlannerSystemPrompt({
+            maxToolCalls,
             readOnly,
             remainingToolCalls,
             toolList,

--- a/src/lib/agent/conversation-context.ts
+++ b/src/lib/agent/conversation-context.ts
@@ -1,5 +1,6 @@
 import type { AgentSessionContext, ChatMessage } from "@/types/agent";
 import { callModelForText } from "@/lib/agent/model-client";
+import { normalizeMaxToolCalls } from "@/lib/agent/tool-run-types";
 
 export const MAX_CONTEXT_MESSAGES = 8;
 
@@ -47,6 +48,8 @@ export function normalizeSessionContext(
     lastReadFilePath: sessionContext.lastReadFilePath?.trim() || null,
     lastToolInput: sessionContext.lastToolInput?.trim() || null,
     lastToolName: sessionContext.lastToolName?.trim() || null,
+    maxToolCalls:
+      normalizeMaxToolCalls(sessionContext.maxToolCalls) ?? undefined,
     projectId: sessionContext.projectId?.trim() || null,
     readOnly: sessionContext.readOnly === true,
     sessionId: sessionContext.sessionId?.trim() || null,

--- a/src/lib/agent/prompts.ts
+++ b/src/lib/agent/prompts.ts
@@ -1,6 +1,5 @@
-import { MAX_TOOL_CALLS } from "./tool-run-types";
-
 type PlannerSystemPromptInput = {
+  maxToolCalls: number;
   readOnly: boolean;
   remainingToolCalls: number;
   toolList: string;
@@ -23,6 +22,7 @@ function buildPlannerBudgetInstruction(
 }
 
 export function buildPlannerSystemPrompt({
+  maxToolCalls,
   readOnly,
   remainingToolCalls,
   toolList,
@@ -31,7 +31,7 @@ export function buildPlannerSystemPrompt({
   return [
     "You are the planning step for a stripped-down coding agent.",
     "You may request at most one tool in each reply.",
-    `The full user request may use at most ${MAX_TOOL_CALLS} tool calls total.`,
+    `The full user request may use at most ${maxToolCalls} tool calls total.`,
     buildPlannerBudgetInstruction(toolRunCount, remainingToolCalls),
     readOnly
       ? "This session is read-only. Do not modify files. The write_file and replace_text tools are unavailable."

--- a/src/lib/agent/run-agent.ts
+++ b/src/lib/agent/run-agent.ts
@@ -10,8 +10,13 @@ import { withWorkspaceRoot } from "@/lib/tools/workspace-path";
 import {
   normalizeSessionContext,
   prepareConversationContext,
+  formatConversationForModel,
+  formatConversationSummaryForModel,
 } from "@/lib/agent/conversation-context";
-import { getConfiguredModelName } from "@/lib/agent/model-client";
+import {
+  callModelForText,
+  getConfiguredModelName,
+} from "@/lib/agent/model-client";
 import {
   createMessage,
   createStep,
@@ -19,15 +24,21 @@ import {
   finishAgentRun,
   type RunAgentOptions,
 } from "@/lib/agent/agent-response";
-import { formatToolExecutionInput } from "@/lib/agent/tool-args";
+import {
+  formatToolExecutionInput,
+  formatToolRunsForModel,
+} from "@/lib/agent/tool-args";
 import {
   APPROVE_WRITE_COMMAND,
   CANCEL_WRITE_COMMAND,
-  MAX_TOOL_CALLS,
   createSyntheticToolCallId,
+  getEffectiveMaxToolCalls,
   type ToolRun,
 } from "@/lib/agent/tool-run-types";
-import { buildNextSessionContext } from "@/lib/agent/session-state";
+import {
+  buildNextSessionContext,
+  formatSessionContextForModel,
+} from "@/lib/agent/session-state";
 import {
   handleAutoWriteApproval,
   handleWriteApproval,
@@ -45,6 +56,75 @@ import {
   thinkStrategies,
   type AgentContext,
 } from "@/lib/agent/agent-thinking";
+
+type TaskCompletionJudgment = {
+  done: boolean;
+  reason: string;
+};
+
+function parseTaskCompletionJudgment(content: string): TaskCompletionJudgment {
+  const jsonText = content.match(/\{[\s\S]*\}/)?.[0] ?? content;
+
+  try {
+    const parsed = JSON.parse(jsonText) as {
+      done?: unknown;
+      reason?: unknown;
+    };
+
+    return {
+      done: parsed.done === true,
+      reason:
+        typeof parsed.reason === "string" && parsed.reason.trim()
+          ? parsed.reason.trim()
+          : "The completion judge did not include a reason.",
+    };
+  } catch {
+    return {
+      done: false,
+      reason: "The completion judge did not return valid JSON.",
+    };
+  }
+}
+
+async function judgeTaskCompletion(
+  context: AgentContext,
+  goal: string,
+  toolRuns: ToolRun[],
+): Promise<TaskCompletionJudgment> {
+  const response = await callModelForText(context.model, [
+    {
+      role: "system",
+      content: [
+        "You are the completion judge for a stripped-down coding agent.",
+        "Decide whether the original user task is complete using only the completed tool results and session context.",
+        "Return only valid JSON with this exact shape: {\"done\": boolean, \"reason\": string}.",
+        "Use done=true only when the user can receive a final answer now without another tool call.",
+        "Use done=false if another tool call is still needed, if a tool failed and recovery is possible, or if the gathered information is not enough.",
+        "If the user asked to modify files, the task is not complete after only reading files.",
+      ].join("\n"),
+    },
+    {
+      role: "user",
+      content: [
+        "Older conversation summary:",
+        formatConversationSummaryForModel(context.sessionContext),
+        "",
+        "Recent conversation:",
+        formatConversationForModel(context.recentConversation),
+        "",
+        "Session reference hints:",
+        formatSessionContextForModel(context.sessionContext),
+        "",
+        `Original task: ${goal}`,
+        "",
+        "Completed tool results:",
+        formatToolRunsForModel(toolRuns),
+      ].join("\n"),
+    },
+  ]);
+
+  return parseTaskCompletionJudgment(response.content);
+}
 
 function createReadOnlyBlockedResponse(
   sessionContext: AgentSessionContext,
@@ -112,6 +192,7 @@ export async function runAgent(
   const effectiveSessionContext: AgentSessionContext = {
     ...normalizedSessionContext,
     autoApprove: normalizedSessionContext.autoApprove === true,
+    maxToolCalls: normalizedSessionContext.maxToolCalls,
     pendingDraft: normalizedSessionContext.pendingDraft ?? null,
     projectId: options.projectId ?? normalizedSessionContext.projectId ?? null,
     readOnly: normalizedSessionContext.readOnly === true,
@@ -384,6 +465,7 @@ export async function runAgent(
 
   while (true) {
     const roundNumber = toolRuns.length + 1;
+    const maxToolCalls = getEffectiveMaxToolCalls(context.sessionContext);
     logger.info("agent loop iteration start", { loopCount: roundNumber });
     const strategy = thinkStrategies.find((strategy) =>
       strategy.match(toolRuns, perception.goal),
@@ -536,7 +618,46 @@ export async function runAgent(
       );
     }
 
-    if (toolRuns.length >= MAX_TOOL_CALLS) {
+    const completionJudgment = await judgeTaskCompletion(
+      context,
+      perception.goal,
+      toolRuns,
+    );
+    await pushStep(
+      createStep(
+        `think-completion-${roundNumber}`,
+        "Think",
+        `Completion check after ${toolRuns.length} tool call${toolRuns.length === 1 ? "" : "s"}: ${completionJudgment.done ? "done" : "continue"}. Reason: ${completionJudgment.reason}`,
+      ),
+    );
+
+    if (completionJudgment.done) {
+      const finalReply = await answerWithToolResults(
+        context,
+        perception.goal,
+        toolRuns,
+      );
+
+      await pushStep(
+        createStep(
+          `act-final-${roundNumber}`,
+          "Act",
+          "Return the final answer because the completion judge marked the task as done.",
+        ),
+      );
+
+      return finishWithLogging(
+        {
+          message: createMessage(finalReply.content, finalReply.reasoning_content),
+          sessionContext: buildNextSessionContext(context.sessionContext, toolRuns),
+          steps,
+        },
+        false,
+        toolRuns.length,
+      );
+    }
+
+    if (toolRuns.length >= maxToolCalls) {
       const finalReply = await answerWithToolResults(
         context,
         perception.goal,
@@ -547,7 +668,7 @@ export async function runAgent(
         createStep(
           `act-${roundNumber}`,
           "Act",
-          `Run tool call ${toolRuns.length} with "${toolRun.name}" and stop there because the tool budget is exhausted. Use all collected tool results to produce the final answer.`,
+          `Run tool call ${toolRuns.length} with "${toolRun.name}" and stop there because the safety tool budget of ${maxToolCalls} is exhausted. Use all collected tool results to produce the final answer.`,
         ),
       );
 

--- a/src/lib/agent/tool-run-types.ts
+++ b/src/lib/agent/tool-run-types.ts
@@ -35,6 +35,24 @@ function readMaxToolCalls() {
 
 export const MAX_TOOL_CALLS = readMaxToolCalls();
 
+export function normalizeMaxToolCalls(value: unknown) {
+  if (
+    typeof value !== "number" ||
+    !Number.isSafeInteger(value) ||
+    value <= 0
+  ) {
+    return null;
+  }
+
+  return value;
+}
+
+export function getEffectiveMaxToolCalls(
+  sessionContext?: { maxToolCalls?: number | null },
+) {
+  return normalizeMaxToolCalls(sessionContext?.maxToolCalls) ?? MAX_TOOL_CALLS;
+}
+
 export function createSyntheticToolCallId() {
   return `tool-call-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -29,6 +29,7 @@ export type AgentSessionContext = {
   lastReadFilePath?: string | null;
   lastToolInput?: string | null;
   lastToolName?: string | null;
+  maxToolCalls?: number;
   pendingDraft?: PendingDraftSnapshot | null;
   pendingWorkspaceSwitch?: PendingWorkspaceSwitch | null;
   projectId?: string | null;


### PR DESCRIPTION
## What changed

- Added a model-driven completion check after each non-immediate tool round.
- Kept the configured tool budget as a safety ceiling instead of the normal stopping mechanism.
- Added `AgentSessionContext.maxToolCalls` and normalized it as a positive integer override.
- Passed request `sessionContext` into the persisted session context so session-level overrides can reach `runAgent`.

## Validation

- `npm run build`
- `npm test`