### PR TITLE
[codex] Add task planner subtasks

### DIFF
--- a/src/lib/agent/agent-response.ts
+++ b/src/lib/agent/agent-response.ts
@@ -7,6 +7,7 @@ import type {
 import type { ToolRun } from "@/lib/agent/tool-run-types";
 
 export type RunAgentOptions = {
+  disableTaskPlanning?: boolean;
   onEvent?: (event: AgentStreamEvent) => void | Promise<void>;
   onToolRun?: (toolRun: ToolRun) => void | Promise<void>;
   projectId?: string;

--- a/src/lib/agent/run-agent.ts
+++ b/src/lib/agent/run-agent.ts
@@ -56,6 +56,17 @@ import {
   thinkStrategies,
   type AgentContext,
 } from "@/lib/agent/agent-thinking";
+import {
+  planTask,
+  runSubtask,
+  shouldDecomposeTask,
+} from "@/lib/agent/task-planner";
+import {
+  createSubtasks,
+  listSubtasksForParentTask,
+  updateSubtaskStatus,
+  type SubtaskRecord,
+} from "@/lib/db/store";
 
 type TaskCompletionJudgment = {
   done: boolean;
@@ -155,6 +166,197 @@ function createReadOnlyBlockedResponse(
         "Stop before modifying files and tell the user how to continue.",
       ),
     ],
+  };
+}
+
+function summarizeSubtaskResult(content: string | null | undefined) {
+  const cleanContent = content?.trim();
+
+  if (!cleanContent) {
+    return "No result text was recorded.";
+  }
+
+  return cleanContent.length > 500
+    ? `${cleanContent.slice(0, 500).trim()}...`
+    : cleanContent;
+}
+
+function createSubtaskSummary(subtasks: SubtaskRecord[]) {
+  return subtasks
+    .map(
+      (subtask, index) =>
+        `${index + 1}. [${subtask.status}] ${subtask.description}\n${summarizeSubtaskResult(subtask.result)}`,
+    )
+    .join("\n\n");
+}
+
+async function runTaskPlanFlow(input: {
+  context: AgentContext;
+  goal: string;
+  pushStep: (step: AgentStep) => Promise<void>;
+  sessionId: string;
+  steps: AgentStep[];
+}) {
+  let subtasks = listSubtasksForParentTask({
+    parentTask: input.goal,
+    sessionId: input.sessionId,
+  });
+
+  if (subtasks.length === 0) {
+    const descriptions = await planTask(input.goal, input.context);
+    subtasks = createSubtasks({
+      descriptions,
+      parentTask: input.goal,
+      sessionId: input.sessionId,
+    });
+
+    await input.pushStep(
+      createStep(
+        "think-task-plan",
+        "Think",
+        `Split the task into ${subtasks.length} subtask${subtasks.length === 1 ? "" : "s"}.`,
+      ),
+    );
+  } else {
+    await input.pushStep(
+      createStep(
+        "think-task-plan",
+        "Think",
+        `Resume ${subtasks.length} existing subtask${subtasks.length === 1 ? "" : "s"} for this parent task. Completed subtasks will not be rerun.`,
+      ),
+    );
+  }
+
+  let currentSessionContext = input.context.sessionContext;
+  const completedSubtasks: SubtaskRecord[] = [];
+
+  for (const subtask of subtasks) {
+    if (subtask.status === "done") {
+      completedSubtasks.push(subtask);
+      continue;
+    }
+
+    let attempts = 0;
+    let finishedSubtask: SubtaskRecord | null = null;
+
+    while (!finishedSubtask && attempts < 2) {
+      attempts += 1;
+      updateSubtaskStatus({
+        id: subtask.id,
+        result: subtask.result,
+        status: "running",
+      });
+      await input.pushStep(
+        createStep(
+          `act-subtask-${subtask.id}-${attempts}`,
+          "Act",
+          attempts === 1
+            ? `Run subtask: ${subtask.description}`
+            : `Retry only the failed subtask: ${subtask.description}`,
+        ),
+      );
+
+      try {
+        const result = await runSubtask(subtask, currentSessionContext);
+        currentSessionContext = result.sessionContext;
+
+        if (
+          result.sessionContext.pendingDraft &&
+          result.sessionContext.autoApprove !== true
+        ) {
+          updateSubtaskStatus({
+            id: subtask.id,
+            result: result.message.content,
+            status: "running",
+          });
+
+          await input.pushStep(
+            createStep(
+              `act-subtask-${subtask.id}-waiting`,
+              "Act",
+              "Pause the task plan because this subtask created a pending write draft that still needs approval.",
+            ),
+          );
+
+          return {
+            message: result.message,
+            sessionContext: result.sessionContext,
+            steps: input.steps,
+          };
+        }
+
+        updateSubtaskStatus({
+          id: subtask.id,
+          result: result.message.content,
+          status: "done",
+        });
+        finishedSubtask = {
+          ...subtask,
+          result: result.message.content,
+          status: "done",
+        };
+        completedSubtasks.push(finishedSubtask);
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Subtask failed.";
+        updateSubtaskStatus({
+          id: subtask.id,
+          result: errorMessage,
+          status: "failed",
+        });
+
+        if (attempts >= 2) {
+          await input.pushStep(
+            createStep(
+              `act-subtask-${subtask.id}-failed`,
+              "Act",
+              `Stop after retrying the failed subtask. Error: ${errorMessage}`,
+            ),
+          );
+
+          return {
+            message: createMessage(
+              [
+                "Task planning stopped because one subtask failed after retry.",
+                "",
+                `Failed subtask: ${subtask.description}`,
+                `Error: ${errorMessage}`,
+                "",
+                "Completed subtasks:",
+                createSubtaskSummary(completedSubtasks),
+              ].join("\n"),
+            ),
+            sessionContext: currentSessionContext,
+            steps: input.steps,
+          };
+        }
+      }
+    }
+  }
+
+  const latestSubtasks = listSubtasksForParentTask({
+    parentTask: input.goal,
+    sessionId: input.sessionId,
+  });
+
+  await input.pushStep(
+    createStep(
+      "act-task-plan-complete",
+      "Act",
+      "All subtasks are done. Return the combined task result.",
+    ),
+  );
+
+  return {
+    message: createMessage(
+      [
+        "Task plan complete.",
+        "",
+        createSubtaskSummary(latestSubtasks),
+      ].join("\n"),
+    ),
+    sessionContext: currentSessionContext,
+    steps: input.steps,
   };
 }
 
@@ -460,6 +662,29 @@ export async function runAgent(
 
   const perception = perceive(context);
   await pushStep(perception.step);
+
+  if (!options.disableTaskPlanning && context.sessionContext.sessionId) {
+    const decomposition = await shouldDecomposeTask(perception.goal, context);
+    await pushStep(
+      createStep(
+        "think-decomposition",
+        "Think",
+        `Task decomposition check: ${decomposition.split ? "split" : "do not split"}. Reason: ${decomposition.reason}`,
+      ),
+    );
+
+    if (decomposition.split) {
+      const taskPlanResponse = await runTaskPlanFlow({
+        context,
+        goal: perception.goal,
+        pushStep,
+        sessionId: context.sessionContext.sessionId,
+        steps,
+      });
+
+      return finishWithLogging(taskPlanResponse, false, 0);
+    }
+  }
 
   const toolRuns: ToolRun[] = [];
 

--- a/src/lib/agent/task-planner.ts
+++ b/src/lib/agent/task-planner.ts
@@ -1,0 +1,139 @@
+import type {
+  AgentResponse,
+  AgentSessionContext,
+} from "@/types/agent";
+import {
+  formatConversationForModel,
+  formatConversationSummaryForModel,
+} from "@/lib/agent/conversation-context";
+import type { AgentContext } from "@/lib/agent/agent-thinking";
+import { callModelForText } from "@/lib/agent/model-client";
+import { formatSessionContextForModel } from "@/lib/agent/session-state";
+import type { SubtaskRecord } from "@/lib/db/store";
+
+export type TaskDecompositionJudgment = {
+  reason: string;
+  split: boolean;
+};
+
+function parseJsonObject(content: string) {
+  const jsonText = content.match(/\{[\s\S]*\}/)?.[0] ?? content;
+
+  try {
+    const parsed = JSON.parse(jsonText) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseStringArray(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export async function shouldDecomposeTask(
+  goal: string,
+  context: AgentContext,
+): Promise<TaskDecompositionJudgment> {
+  const response = await callModelForText(context.model, [
+    {
+      role: "system",
+      content: [
+        "You are a task decomposition judge for a coding agent.",
+        "Decide whether the user's current task should be split into independent subtasks before execution.",
+        "Return only valid JSON with this exact shape: {\"split\": boolean, \"reason\": string}.",
+        "Use split=true for broad multi-file implementation work, multi-step refactors, or tasks that naturally have separate investigation, implementation, and validation phases.",
+        "Use split=false for simple questions, single direct edits, draft approval/cancel flows, workspace switching, and tasks that one normal agent loop can handle directly.",
+      ].join("\n"),
+    },
+    {
+      role: "user",
+      content: [
+        "Older conversation summary:",
+        formatConversationSummaryForModel(context.sessionContext),
+        "",
+        "Recent conversation:",
+        formatConversationForModel(context.recentConversation),
+        "",
+        "Session reference hints:",
+        formatSessionContextForModel(context.sessionContext),
+        "",
+        `Current task: ${goal}`,
+      ].join("\n"),
+    },
+  ]);
+
+  const parsed = parseJsonObject(response.content);
+
+  return {
+    split: parsed?.split === true,
+    reason:
+      typeof parsed?.reason === "string" && parsed.reason.trim()
+        ? parsed.reason.trim()
+        : "The decomposition judge did not include a reason.",
+  };
+}
+
+export async function planTask(goal: string, context: AgentContext) {
+  const response = await callModelForText(context.model, [
+    {
+      role: "system",
+      content: [
+        "You break a coding-agent task into a short ordered subtask list.",
+        "Return only valid JSON with this exact shape: {\"subtasks\": string[]}.",
+        "Each subtask must be independently runnable by the same agent.",
+        "Keep subtasks concrete and outcome-focused.",
+        "Do not include a subtask that only says to report back.",
+        "Prefer 2 to 5 subtasks.",
+      ].join("\n"),
+    },
+    {
+      role: "user",
+      content: [
+        "Older conversation summary:",
+        formatConversationSummaryForModel(context.sessionContext),
+        "",
+        "Recent conversation:",
+        formatConversationForModel(context.recentConversation),
+        "",
+        "Session reference hints:",
+        formatSessionContextForModel(context.sessionContext),
+        "",
+        `Task to split: ${goal}`,
+      ].join("\n"),
+    },
+  ]);
+
+  const parsed = parseJsonObject(response.content);
+  const subtasks = parseStringArray(parsed?.subtasks);
+
+  return subtasks.length > 0 ? subtasks : [goal];
+}
+
+export async function runSubtask(
+  subtask: SubtaskRecord,
+  sessionContext: AgentSessionContext,
+): Promise<AgentResponse> {
+  const { runAgent } = await import("@/lib/agent/run-agent");
+  const task = [
+    `Parent task: ${subtask.parentTask}`,
+    `Current subtask: ${subtask.description}`,
+    "",
+    "Complete only the current subtask. Use the existing automatic loop. Do not re-plan the parent task.",
+  ].join("\n");
+
+  return runAgent(task, [], sessionContext, `subtask_${subtask.id}`, {
+    disableTaskPlanning: true,
+    projectId: sessionContext.projectId ?? undefined,
+    sessionId: sessionContext.sessionId ?? undefined,
+  });
+}

--- a/src/lib/db/migrations/003_add_subtasks.sql
+++ b/src/lib/db/migrations/003_add_subtasks.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS subtasks (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  parent_task TEXT NOT NULL,
+  description TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('pending', 'running', 'done', 'failed')),
+  result TEXT,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_subtasks_session_parent
+  ON subtasks(session_id, parent_task, created_at);

--- a/src/lib/db/store.ts
+++ b/src/lib/db/store.ts
@@ -45,6 +45,28 @@ type MessageRow = {
   role: "user" | "assistant";
 };
 
+export type SubtaskStatus = "pending" | "running" | "done" | "failed";
+
+export type SubtaskRecord = {
+  createdAt: number;
+  description: string;
+  id: string;
+  parentTask: string;
+  result: string | null;
+  sessionId: string;
+  status: SubtaskStatus;
+};
+
+type SubtaskRow = {
+  created_at: number;
+  description: string;
+  id: string;
+  parent_task: string;
+  result: string | null;
+  session_id: string;
+  status: SubtaskStatus;
+};
+
 const starterSteps: AgentStep[] = [
   {
     id: "waiting",
@@ -93,6 +115,18 @@ function mapProjectSummary(row: ProjectRow, sessions: SessionSummary[]): Project
   };
 }
 
+function mapSubtask(row: SubtaskRow): SubtaskRecord {
+  return {
+    createdAt: row.created_at,
+    description: row.description,
+    id: row.id,
+    parentTask: row.parent_task,
+    result: row.result,
+    sessionId: row.session_id,
+    status: row.status,
+  };
+}
+
 function listSessionRowsForProject(projectId: string) {
   return getDb()
     .prepare(
@@ -102,6 +136,78 @@ function listSessionRowsForProject(projectId: string) {
        ORDER BY updated_at DESC`,
     )
     .all(projectId) as SessionRow[];
+}
+
+export function listSubtasksForParentTask(input: {
+  parentTask: string;
+  sessionId: string;
+}) {
+  const rows = getDb()
+    .prepare(
+      `SELECT id, session_id, parent_task, description, status, result, created_at
+       FROM subtasks
+       WHERE session_id = ? AND parent_task = ?
+       ORDER BY created_at ASC`,
+    )
+    .all(input.sessionId, input.parentTask) as SubtaskRow[];
+
+  return rows.map(mapSubtask);
+}
+
+export function createSubtasks(input: {
+  descriptions: string[];
+  parentTask: string;
+  sessionId: string;
+}) {
+  const timestamp = now();
+  const db = getDb();
+  const insert = db.prepare(
+    `INSERT INTO subtasks
+      (id, session_id, parent_task, description, status, result, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  );
+
+  const created = db.transaction(() =>
+    input.descriptions.map((description) => {
+      const row: SubtaskRow = {
+        created_at: timestamp,
+        description,
+        id: createId("subtask"),
+        parent_task: input.parentTask,
+        result: null,
+        session_id: input.sessionId,
+        status: "pending",
+      };
+
+      insert.run(
+        row.id,
+        row.session_id,
+        row.parent_task,
+        row.description,
+        row.status,
+        row.result,
+        row.created_at,
+      );
+
+      return row;
+    }),
+  )();
+
+  return created.map(mapSubtask);
+}
+
+export function updateSubtaskStatus(input: {
+  id: string;
+  result?: string | null;
+  status: SubtaskStatus;
+}) {
+  getDb()
+    .prepare(
+      `UPDATE subtasks
+       SET status = ?, result = ?
+       WHERE id = ?`,
+    )
+    .run(input.status, input.result ?? null, input.id);
 }
 
 export function createProject(input: {


### PR DESCRIPTION
﻿## What changed

- Added `003_add_subtasks.sql` with a `subtasks` table for session-scoped task plans.
- Added `src/lib/agent/task-planner.ts` with task decomposition, task planning, and subtask execution helpers.
- Integrated task decomposition into `run-agent.ts` before the normal tool loop.
- Subtasks are persisted and resumed by parent task; completed subtasks are skipped, and a failed subtask is retried without restarting earlier subtasks.

## Validation

- `npm run build`
- `npm test`
- SQLite migration smoke test for `001_init.sql`, `002_add_auto_approve.sql`, and `003_add_subtasks.sql`
