### PR TITLE
[codex] Handle failed subtask commands

### DIFF
--- a/src/lib/agent/run-agent.ts
+++ b/src/lib/agent/run-agent.ts
@@ -190,6 +190,21 @@ function createSubtaskSummary(subtasks: SubtaskRecord[]) {
     .join("\n\n");
 }
 
+function getSubtaskBlockingFailure(toolRuns: ToolRun[]) {
+  const failedCommand = toolRuns.find(
+    (toolRun) => toolRun.name === "safe_command" && !toolRun.result.ok,
+  );
+
+  if (!failedCommand) {
+    return null;
+  }
+
+  return [
+    `Subtask command failed: ${failedCommand.inputText}`,
+    failedCommand.result.content,
+  ].join("\n");
+}
+
 async function runTaskPlanFlow(input: {
   context: AgentContext;
   goal: string;
@@ -257,7 +272,12 @@ async function runTaskPlanFlow(input: {
       );
 
       try {
-        const result = await runSubtask(subtask, currentSessionContext);
+        const subtaskToolRuns: ToolRun[] = [];
+        const result = await runSubtask(subtask, currentSessionContext, {
+          onToolRun(toolRun) {
+            subtaskToolRuns.push(toolRun);
+          },
+        });
         currentSessionContext = result.sessionContext;
 
         if (
@@ -283,6 +303,43 @@ async function runTaskPlanFlow(input: {
             sessionContext: result.sessionContext,
             steps: input.steps,
           };
+        }
+
+        const blockingFailure = getSubtaskBlockingFailure(subtaskToolRuns);
+        if (blockingFailure) {
+          updateSubtaskStatus({
+            id: subtask.id,
+            result: blockingFailure,
+            status: "failed",
+          });
+
+          if (attempts >= 2) {
+            await input.pushStep(
+              createStep(
+                `act-subtask-${subtask.id}-failed`,
+                "Act",
+                `Stop after retrying the failed subtask. Error: ${blockingFailure}`,
+              ),
+            );
+
+            return {
+              message: createMessage(
+                [
+                  "Task planning stopped because one subtask failed after retry.",
+                  "",
+                  `Failed subtask: ${subtask.description}`,
+                  `Error: ${blockingFailure}`,
+                  "",
+                  "Completed subtasks:",
+                  createSubtaskSummary(completedSubtasks),
+                ].join("\n"),
+              ),
+              sessionContext: currentSessionContext,
+              steps: input.steps,
+            };
+          }
+
+          continue;
         }
 
         updateSubtaskStatus({

--- a/src/lib/agent/task-planner.ts
+++ b/src/lib/agent/task-planner.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/agent/conversation-context";
 import type { AgentContext } from "@/lib/agent/agent-thinking";
 import { callModelForText } from "@/lib/agent/model-client";
+import type { ToolRun } from "@/lib/agent/tool-run-types";
 import { formatSessionContextForModel } from "@/lib/agent/session-state";
 import type { SubtaskRecord } from "@/lib/db/store";
 
@@ -122,6 +123,7 @@ export async function planTask(goal: string, context: AgentContext) {
 export async function runSubtask(
   subtask: SubtaskRecord,
   sessionContext: AgentSessionContext,
+  options: { onToolRun?: (toolRun: ToolRun) => void } = {},
 ): Promise<AgentResponse> {
   const { runAgent } = await import("@/lib/agent/run-agent");
   const task = [
@@ -133,6 +135,7 @@ export async function runSubtask(
 
   return runAgent(task, [], sessionContext, `subtask_${subtask.id}`, {
     disableTaskPlanning: true,
+    onToolRun: options.onToolRun,
     projectId: sessionContext.projectId ?? undefined,
     sessionId: sessionContext.sessionId ?? undefined,
   });


### PR DESCRIPTION
﻿## What changed

- Treat failed `safe_command` results inside task-planner subtasks as blocking failures.
- Capture subtask tool runs so the parent task plan can mark the subtask `failed` instead of `done`.
- Retry only the failed subtask once, then stop with a clear failure summary.

## Why

A subtask could return an assistant message containing a failed or rejected command result, but the task planner still marked that subtask as `done`. That made failed validation look like a completed task plan.

## Validation

- `npm run build`
- `npm test`
