### PR TITLE
feat: add grounded agent reliability controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "test": "tsc -p tsconfig.test.json && node --test .test-dist/test/safe-command.test.js"
+    "test": "tsc -p tsconfig.test.json && node --test .test-dist/test/*.js"
   },
   "dependencies": {
     "better-sqlite3": "^12.10.0",

--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -9,11 +9,14 @@ import {
   createCheckpoint,
   getSessionProject,
   recordToolRun,
+  updateSessionSettings,
   updateSessionState,
 } from "@/lib/db/store";
 import { createLogger } from "@/lib/logger";
 import { withWorkspaceRoot } from "@/lib/tools/workspace-path";
 import type { AgentRequest, AgentStreamEvent } from "@/types/agent";
+import { parseSessionSettingCommand } from "@/lib/agent/intent";
+import { requireAgentApiAuth } from "@/lib/api-auth";
 
 const encoder = new TextEncoder();
 export const runtime = "nodejs";
@@ -44,19 +47,9 @@ function createImmediateStream(events: AgentStreamEvent[]) {
 }
 
 export async function POST(request: Request) {
-  const agentApiSecret = process.env.AGENT_API_SECRET?.trim();
-  const authorization = request.headers.get("authorization");
-
-  if (!agentApiSecret) {
-    console.warn(
-      "AGENT_API_SECRET is not set. Rejecting /api/agent requests until server-side auth is configured.",
-    );
-
-    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
-  }
-
-  if (authorization !== `Bearer ${agentApiSecret}`) {
-    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  const unauthorized = requireAgentApiAuth(request);
+  if (unauthorized) {
+    return unauthorized;
   }
 
   const requestId = "req_" + Math.random().toString(36).slice(2, 8);
@@ -107,12 +100,56 @@ export async function POST(request: Request) {
     sessionId,
   });
   const messagesForAgent = [...session.messages, userMessage];
+  const clientSessionContext = body.sessionContext ?? {};
   const sessionContext = {
     ...session.sessionContext,
-    ...body.sessionContext,
+    ...(typeof clientSessionContext.maxToolCalls === "number"
+      ? { maxToolCalls: clientSessionContext.maxToolCalls }
+      : {}),
     projectId: project.id,
     sessionId,
   };
+  const settingCommand = parseSessionSettingCommand(task);
+
+  if (settingCommand?.kind === "autoApprove") {
+    const updatedSession = updateSessionSettings(sessionId, {
+      autoApprove: settingCommand.autoApprove,
+    });
+    const nextSessionContext = updatedSession?.sessionContext ?? {
+      ...sessionContext,
+      autoApprove: settingCommand.autoApprove,
+    };
+    const message = settingCommand.autoApprove
+      ? "autoApprove is now enabled for this session. Read-only mode still blocks file writes."
+      : "autoApprove is now disabled for this session.";
+    const assistantMessage = appendMessage({
+      content: message,
+      role: "assistant",
+      sessionId,
+    });
+    const result = {
+      message: assistantMessage,
+      sessionContext: nextSessionContext,
+      steps: [
+        {
+          id: "settings",
+          title: "Act",
+          detail: "Persist the requested session setting before running the agent loop.",
+          status: "done" as const,
+        },
+      ],
+    };
+
+    if (body.stream) {
+      return createImmediateStream([
+        { type: "steps", steps: result.steps },
+        { type: "message", message: result.message },
+        { type: "done", sessionContext: result.sessionContext },
+      ]);
+    }
+
+    return NextResponse.json(result);
+  }
   const workspaceSwitchResult = handleWorkspaceSwitchTask({
     projectId: project.id,
     projectWorkspacePath: project.workspacePath,
@@ -180,11 +217,21 @@ export async function POST(request: Request) {
   if (body.stream) {
     const stream = new ReadableStream<Uint8Array>({
       async start(controller) {
+        let closed = false;
+        const safeEnqueue = (event: AgentStreamEvent | { type: "error"; message: string }) => {
+          if (closed || request.signal.aborted) {
+            return;
+          }
+
+          controller.enqueue(serializeStreamEvent(event));
+        };
+
         try {
           const result = await withWorkspaceRoot(effectiveWorkspacePath, () =>
             runAgent(task, messagesForAgent, sessionContext, requestId, {
+              emitFinalEvents: false,
               onEvent(event) {
-                controller.enqueue(serializeStreamEvent(event));
+                safeEnqueue(event);
               },
               onToolRun(toolRun) {
                 recordToolRun({
@@ -205,7 +252,7 @@ export async function POST(request: Request) {
             }),
           );
 
-          appendMessage({
+          const assistantMessage = appendMessage({
             content: result.message.content,
             reasoningContent: result.message.reasoning_content ?? null,
             role: "assistant",
@@ -224,20 +271,23 @@ export async function POST(request: Request) {
           logger.info("agent request completed", {
             durationMs: Date.now() - startTime,
           });
+          safeEnqueue({ type: "message", message: assistantMessage });
+          safeEnqueue({ type: "done", sessionContext: result.sessionContext });
         } catch (error) {
           const message =
             error instanceof Error ? error.message : "The agent request failed.";
 
           logger.error("agent request failed", { error: message });
 
-          controller.enqueue(
-            serializeStreamEvent({
-              type: "error",
-              message,
-            }),
-          );
+          safeEnqueue({
+            type: "error",
+            message,
+          });
         } finally {
-          controller.close();
+          closed = true;
+          if (!request.signal.aborted) {
+            controller.close();
+          }
         }
       },
     });

--- a/src/app/api/projects/[projectId]/sessions/route.ts
+++ b/src/app/api/projects/[projectId]/sessions/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createSession, ensureWorkbench } from "@/lib/db/store";
+import { requireAgentApiAuth } from "@/lib/api-auth";
 
 export const runtime = "nodejs";
 
@@ -7,6 +8,11 @@ export async function POST(
   request: Request,
   context: { params: Promise<{ projectId: string }> },
 ) {
+  const unauthorized = requireAgentApiAuth(request);
+  if (unauthorized) {
+    return unauthorized;
+  }
+
   const { projectId } = await context.params;
   let body: { autoApprove?: unknown; title?: unknown } = {};
 

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,13 +1,24 @@
 import { NextResponse } from "next/server";
 import { createProject, ensureWorkbench } from "@/lib/db/store";
+import { requireAgentApiAuth } from "@/lib/api-auth";
 
 export const runtime = "nodejs";
 
-export async function GET() {
+export async function GET(request: Request) {
+  const unauthorized = requireAgentApiAuth(request);
+  if (unauthorized) {
+    return unauthorized;
+  }
+
   return NextResponse.json(ensureWorkbench());
 }
 
 export async function POST(request: Request) {
+  const unauthorized = requireAgentApiAuth(request);
+  if (unauthorized) {
+    return unauthorized;
+  }
+
   let body: {
     confirmWorkspace?: unknown;
     name?: unknown;

--- a/src/app/api/sessions/[sessionId]/route.ts
+++ b/src/app/api/sessions/[sessionId]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getSession } from "@/lib/db/store";
+import { requireAgentApiAuth } from "@/lib/api-auth";
 
 export const runtime = "nodejs";
 
@@ -7,6 +8,11 @@ export async function GET(
   request: Request,
   context: { params: Promise<{ sessionId: string }> },
 ) {
+  const unauthorized = requireAgentApiAuth(request);
+  if (unauthorized) {
+    return unauthorized;
+  }
+
   const { sessionId } = await context.params;
   const session = getSession(sessionId);
 

--- a/src/app/api/sessions/[sessionId]/settings/route.ts
+++ b/src/app/api/sessions/[sessionId]/settings/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import {
+  ensureWorkbench,
+  updateSessionSettings,
+} from "@/lib/db/store";
+import { requireAgentApiAuth } from "@/lib/api-auth";
+
+export const runtime = "nodejs";
+
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ sessionId: string }> },
+) {
+  const unauthorized = requireAgentApiAuth(request);
+  if (unauthorized) {
+    return unauthorized;
+  }
+
+  const { sessionId } = await context.params;
+  let body: { autoApprove?: unknown };
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Request body must be valid JSON." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const session = updateSessionSettings(sessionId, {
+      autoApprove:
+        typeof body.autoApprove === "boolean" ? body.autoApprove : undefined,
+    });
+
+    return NextResponse.json({
+      session,
+      snapshot: ensureWorkbench(),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Session settings could not be updated.",
+      },
+      { status: 400 },
+    );
+  }
+}

--- a/src/app/api/sessions/[sessionId]/tool-runs/route.ts
+++ b/src/app/api/sessions/[sessionId]/tool-runs/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { listToolRuns } from "@/lib/db/store";
+import { requireAgentApiAuth } from "@/lib/api-auth";
 
 export const runtime = "nodejs";
 
@@ -7,6 +8,11 @@ export async function GET(
   request: Request,
   context: { params: Promise<{ sessionId: string }> },
 ) {
+  const unauthorized = requireAgentApiAuth(request);
+  if (unauthorized) {
+    return unauthorized;
+  }
+
   const { sessionId } = await context.params;
 
   return NextResponse.json({

--- a/src/components/chat/chat-shell.tsx
+++ b/src/components/chat/chat-shell.tsx
@@ -64,6 +64,13 @@ const loadingSteps: AgentStep[] = [
 const thinkingFragments = ["top", "right", "bottom", "left"] as const;
 const agentApiSecret = process.env.NEXT_PUBLIC_AGENT_API_SECRET?.trim();
 
+function apiHeaders(extraHeaders: Record<string, string> = {}) {
+  return {
+    ...extraHeaders,
+    ...(agentApiSecret ? { Authorization: `Bearer ${agentApiSecret}` } : {}),
+  };
+}
+
 type AgentErrorEvent = {
   message: string;
   type: "error";
@@ -179,7 +186,9 @@ export function ChatShell() {
   }, [messages]);
 
   async function loadWorkbench(selectSessionId?: string) {
-    const response = await fetch("/api/projects");
+    const response = await fetch("/api/projects", {
+      headers: apiHeaders(),
+    });
     if (!response.ok) {
       throw new Error(await readBackendErrorMessage(response));
     }
@@ -194,7 +203,9 @@ export function ChatShell() {
   }
 
   async function loadSession(sessionId: string) {
-    const response = await fetch(`/api/sessions/${sessionId}`);
+    const response = await fetch(`/api/sessions/${sessionId}`, {
+      headers: apiHeaders(),
+    });
     if (!response.ok) {
       throw new Error(await readBackendErrorMessage(response));
     }
@@ -298,12 +309,7 @@ export function ChatShell() {
       };
       const response = await fetch("/api/agent", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(agentApiSecret
-            ? { Authorization: `Bearer ${agentApiSecret}` }
-            : {}),
-        },
+        headers: apiHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify(payload),
       });
 
@@ -389,6 +395,30 @@ export function ChatShell() {
     await submitTask(task, displayTask);
   }
 
+  async function updateAutoApprove(autoApprove: boolean) {
+    if (!activeSession || isLoading) {
+      return;
+    }
+
+    const response = await fetch(`/api/sessions/${activeSession.id}/settings`, {
+      method: "PATCH",
+      headers: apiHeaders({ "Content-Type": "application/json" }),
+      body: JSON.stringify({ autoApprove }),
+    });
+
+    if (!response.ok) {
+      window.alert(await readBackendErrorMessage(response));
+      return;
+    }
+
+    const payload = (await response.json()) as {
+      session: SessionDetail;
+      snapshot: WorkbenchSnapshot;
+    };
+    setSnapshot(payload.snapshot);
+    setActiveSession(payload.session);
+  }
+
   async function createProjectFromPrompt() {
     if (isLoading) {
       return;
@@ -414,7 +444,7 @@ export function ChatShell() {
 
     const response = await fetch("/api/projects", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: apiHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify({
         confirmWorkspace: true,
         name,
@@ -445,7 +475,7 @@ export function ChatShell() {
 
     const response = await fetch(`/api/projects/${projectId}/sessions`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: apiHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify({ title: "New session" }),
     });
 
@@ -577,8 +607,19 @@ export function ChatShell() {
               <p className="session-subtitle">
                 {formatActiveWorkspacePath(activeProject, sessionContext)}
                 {sessionContext.readOnly ? " | read-only" : ""}
+                {sessionContext.autoApprove ? " | autoApprove on" : " | autoApprove off"}
               </p>
             </div>
+            {activeSession ? (
+              <button
+                className="small-button"
+                type="button"
+                disabled={isLoading || sessionContext.readOnly === true}
+                onClick={() => void updateAutoApprove(!sessionContext.autoApprove)}
+              >
+                {sessionContext.autoApprove ? "Disable autoApprove" : "Enable autoApprove"}
+              </button>
+            ) : null}
           </div>
 
           <div ref={messageViewportRef} className="message-viewport">

--- a/src/lib/agent/agent-response.ts
+++ b/src/lib/agent/agent-response.ts
@@ -8,6 +8,7 @@ import type { ToolRun } from "@/lib/agent/tool-run-types";
 
 export type RunAgentOptions = {
   disableTaskPlanning?: boolean;
+  emitFinalEvents?: boolean;
   onEvent?: (event: AgentStreamEvent) => void | Promise<void>;
   onToolRun?: (toolRun: ToolRun) => void | Promise<void>;
   projectId?: string;
@@ -65,9 +66,14 @@ export async function finishAgentRun(
   response: AgentResponse,
   onEvent: RunAgentOptions["onEvent"],
   includeSteps: boolean,
+  emitFinalEvents = true,
 ) {
   if (includeSteps) {
     await emitStepsSnapshot(response.steps, onEvent);
+  }
+
+  if (!emitFinalEvents) {
+    return response;
   }
 
   await emitAgentEvent(onEvent, {

--- a/src/lib/agent/conversation-context.ts
+++ b/src/lib/agent/conversation-context.ts
@@ -52,6 +52,24 @@ export function normalizeSessionContext(
       normalizeMaxToolCalls(sessionContext.maxToolCalls) ?? undefined,
     projectId: sessionContext.projectId?.trim() || null,
     readOnly: sessionContext.readOnly === true,
+    requiredValidations: Array.isArray(sessionContext.requiredValidations)
+      ? sessionContext.requiredValidations
+          .filter(
+            (validation) =>
+              validation &&
+              typeof validation.command === "string" &&
+              Array.isArray(validation.args) &&
+              typeof validation.id === "string" &&
+              typeof validation.label === "string",
+          )
+          .map((validation) => ({
+            ...validation,
+            args: validation.args.filter((arg): arg is string => typeof arg === "string"),
+            command: validation.command.trim(),
+            id: validation.id.trim(),
+            label: validation.label.trim(),
+          }))
+      : undefined,
     sessionId: sessionContext.sessionId?.trim() || null,
     workspacePathOverride: sessionContext.workspacePathOverride?.trim() || null,
     pendingDraft: sessionContext.pendingDraft

--- a/src/lib/agent/intent.ts
+++ b/src/lib/agent/intent.ts
@@ -1,0 +1,165 @@
+import {
+  getStringArg,
+  getStringArrayArg,
+} from "./tool-args";
+import type { ToolExecutionInput } from "@/lib/tools/types";
+
+export type CommandIntent = "diagnostic" | "validation" | "build_check" | "lint_check";
+
+export type RequiredValidation = {
+  id: string;
+  command: string;
+  args: string[];
+  label: string;
+  satisfiedByToolCallId?: string;
+  satisfiedAt?: number;
+  lastFailure?: string;
+};
+
+export type SessionSettingCommand =
+  | {
+      autoApprove: boolean;
+      kind: "autoApprove";
+    }
+  | null;
+
+export function isFileModificationRequest(task: string) {
+  return (
+    /(modify|edit|update|change|append|replace|rewrite|revise|write|create|overwrite|delete|remove|fix|repair|apply|implement)/i.test(task) ||
+    /(修改|编辑|更新|改动|更改|追加|替换|重写|删除|增加|修复|修好|应用修复|实现|写入|改一下|改好|你倒是修)/u.test(task)
+  );
+}
+
+export function looksLikeManualEditInstructions(text: string) {
+  return (
+    /(manually|by hand|copy this|paste this|you should edit|change .* to |replace .* with )/i.test(text) ||
+    /(手动|自己修改|你需要修改|把.+改成|替换为|请在.+里改)/u.test(text)
+  );
+}
+
+export function parseSessionSettingCommand(task: string): SessionSettingCommand {
+  const cleanTask = task.trim();
+
+  if (
+    /^(?:auto\s*approve|autoApprove)\s*[:=]?\s*(?:true|on|yes|enable|enabled)$/i.test(cleanTask) ||
+    /^(?:打开|开启|启用).{0,8}(?:auto\s*approve|autoApprove|全自动|自动批准|自动应用)/u.test(cleanTask)
+  ) {
+    return {
+      autoApprove: true,
+      kind: "autoApprove",
+    };
+  }
+
+  if (
+    /^(?:auto\s*approve|autoApprove)\s*[:=]?\s*(?:false|off|no|disable|disabled)$/i.test(cleanTask) ||
+    /^(?:关闭|禁用).{0,8}(?:auto\s*approve|autoApprove|全自动|自动批准|自动应用)/u.test(cleanTask)
+  ) {
+    return {
+      autoApprove: false,
+      kind: "autoApprove",
+    };
+  }
+
+  return null;
+}
+
+function createValidation(command: string, args: string[], label: string): RequiredValidation {
+  return {
+    id: `validation:${command}:${args.join(" ")}`,
+    command,
+    args,
+    label,
+  };
+}
+
+function dedupeValidations(validations: RequiredValidation[]) {
+  const seen = new Set<string>();
+  return validations.filter((validation) => {
+    const key = `${validation.command}\0${validation.args.join("\0")}`;
+    if (seen.has(key)) {
+      return false;
+    }
+
+    seen.add(key);
+    return true;
+  });
+}
+
+export function extractRequiredValidations(task: string) {
+  const validations: RequiredValidation[] = [];
+
+  if (/\bnpm\s+(?:run\s+)?test\b/i.test(task) || /(?:运行|跑|执行).{0,8}(?:npm\s+test|npm\s+run\s+test|测试)/u.test(task)) {
+    validations.push(createValidation("npm", ["test"], "npm test"));
+  }
+
+  if (/\bnpm\s+run\s+build\b/i.test(task) || /(?:运行|跑|执行).{0,8}(?:npm\s+run\s+build|构建|编译)/u.test(task)) {
+    validations.push(createValidation("npm", ["run", "build"], "npm run build"));
+  }
+
+  if (/\bnpm\s+run\s+lint\b/i.test(task) || /(?:运行|跑|执行).{0,8}(?:npm\s+run\s+lint|lint|代码检查)/iu.test(task)) {
+    validations.push(createValidation("npm", ["run", "lint"], "npm run lint"));
+  }
+
+  return dedupeValidations(validations);
+}
+
+export function getSafeCommandParts(input: ToolExecutionInput) {
+  if (typeof input === "string") {
+    return null;
+  }
+
+  const command = getStringArg(input, "command").toLowerCase();
+  const args = getStringArrayArg(input, "args");
+
+  return command ? { command, args } : null;
+}
+
+export function isSameCommand(
+  left: { command: string; args: string[] },
+  right: { command: string; args: string[] },
+) {
+  return (
+    left.command === right.command &&
+    left.args.length === right.args.length &&
+    left.args.every((arg, index) => arg === right.args[index])
+  );
+}
+
+export function classifySafeCommandIntent(
+  input: ToolExecutionInput,
+  task: string,
+  hasAppliedOrDraftedWrite: boolean,
+): CommandIntent {
+  const command = getSafeCommandParts(input);
+
+  if (!command) {
+    return "diagnostic";
+  }
+
+  if (
+    command.command === "npm" &&
+    command.args[0] === "run" &&
+    command.args[1] === "build"
+  ) {
+    return "build_check";
+  }
+
+  if (
+    command.command === "npm" &&
+    command.args[0] === "run" &&
+    command.args[1] === "lint"
+  ) {
+    return "lint_check";
+  }
+
+  if (
+    (command.command === "npm" && command.args[0] === "test") ||
+    (command.command === "npm" && command.args[0] === "run" && command.args[1] === "test")
+  ) {
+    return hasAppliedOrDraftedWrite || !/(fix|repair|failing|失败|修复|修好)/iu.test(task)
+      ? "validation"
+      : "diagnostic";
+  }
+
+  return hasAppliedOrDraftedWrite ? "validation" : "diagnostic";
+}

--- a/src/lib/agent/run-agent.ts
+++ b/src/lib/agent/run-agent.ts
@@ -50,12 +50,23 @@ import { runToolCall } from "@/lib/agent/tool-runner";
 import {
   answerDirectly,
   answerWithToolResults,
-  isFileModificationRequest,
   perceive,
   think,
   thinkStrategies,
   type AgentContext,
 } from "@/lib/agent/agent-thinking";
+import {
+  classifySafeCommandIntent,
+  extractRequiredValidations,
+  isFileModificationRequest,
+  looksLikeManualEditInstructions,
+} from "@/lib/agent/intent";
+import {
+  createRunLedger,
+  formatGroundingSummary,
+  getMissingRequiredValidations,
+  recordLedgerToolRun,
+} from "@/lib/agent/run-ledger";
 import {
   planTask,
   runSubtask,
@@ -190,9 +201,65 @@ function createSubtaskSummary(subtasks: SubtaskRecord[]) {
     .join("\n\n");
 }
 
-function getSubtaskBlockingFailure(toolRuns: ToolRun[]) {
+function hasSafeCommandToolName(toolName: string | null) {
+  return toolName === "safe_command";
+}
+
+function createGroundedFinalMessage(input: {
+  content: string;
+  goal: string;
+  ledger: ReturnType<typeof createRunLedger>;
+  reasoningContent?: string | null;
+}) {
+  const wantsEdit = isFileModificationRequest(input.goal);
+  const missingValidations = getMissingRequiredValidations(input.ledger);
+  const needsGrounding =
+    (wantsEdit && !input.ledger.appliedOrDraftedWrite) ||
+    missingValidations.length > 0 ||
+    looksLikeManualEditInstructions(input.content);
+
+  if (!needsGrounding) {
+    return createMessage(input.content, input.reasoningContent ?? null);
+  }
+
+  const groundedLines = [input.content.trim(), "", formatGroundingSummary(input.ledger)];
+
+  if (wantsEdit && !input.ledger.appliedOrDraftedWrite) {
+    groundedLines.push(
+      "",
+      "I did not modify any files in this run because there was no successful write_file or replace_text tool result.",
+    );
+  }
+
+  if (missingValidations.length > 0) {
+    groundedLines.push(
+      "",
+      `I cannot mark this task complete yet. Missing or failed required validation: ${missingValidations.map((validation) => validation.label).join(", ")}.`,
+    );
+  }
+
+  return createMessage(groundedLines.join("\n"), input.reasoningContent ?? null);
+}
+
+function withLedgerSessionContext(
+  sessionContext: AgentSessionContext,
+  ledger: ReturnType<typeof createRunLedger>,
+): AgentSessionContext {
+  return {
+    ...sessionContext,
+    requiredValidations:
+      ledger.requiredValidations.length > 0
+        ? ledger.requiredValidations
+        : sessionContext.requiredValidations,
+  };
+}
+
+function getSubtaskBlockingFailure(goal: string, toolRuns: ToolRun[]) {
   const failedCommand = toolRuns.find(
-    (toolRun) => toolRun.name === "safe_command" && !toolRun.result.ok,
+    (toolRun) =>
+      toolRun.name === "safe_command" &&
+      !toolRun.result.ok &&
+      classifySafeCommandIntent(toolRun.input, goal, false) !== "diagnostic",
   );
 
   if (!failedCommand) {
@@ -208,6 +275,8 @@ function getSubtaskBlockingFailure(toolRuns: ToolRun[]) {
 async function runTaskPlanFlow(input: {
   context: AgentContext;
   goal: string;
+  ledger: ReturnType<typeof createRunLedger>;
+  onToolRun?: (toolRun: ToolRun) => Promise<void> | void;
   pushStep: (step: AgentStep) => Promise<void>;
   sessionId: string;
   steps: AgentStep[];
@@ -276,6 +345,8 @@ async function runTaskPlanFlow(input: {
         const result = await runSubtask(subtask, currentSessionContext, {
           onToolRun(toolRun) {
             subtaskToolRuns.push(toolRun);
+            recordLedgerToolRun(input.ledger, input.goal, toolRun);
+            void input.onToolRun?.(toolRun);
           },
         });
         currentSessionContext = result.sessionContext;
@@ -305,7 +376,10 @@ async function runTaskPlanFlow(input: {
           };
         }
 
-        const blockingFailure = getSubtaskBlockingFailure(subtaskToolRuns);
+        const blockingFailure = getSubtaskBlockingFailure(
+          input.goal,
+          subtaskToolRuns,
+        );
         if (blockingFailure) {
           updateSubtaskStatus({
             id: subtask.id,
@@ -410,9 +484,11 @@ async function runTaskPlanFlow(input: {
         "Task plan complete.",
         "",
         createSubtaskSummary(latestSubtasks),
+        "",
+        formatGroundingSummary(input.ledger),
       ].join("\n"),
     ),
-    sessionContext: currentSessionContext,
+    sessionContext: withLedgerSessionContext(currentSessionContext, input.ledger),
     steps: input.steps,
   };
 }
@@ -427,7 +503,7 @@ export async function runAgent(
   const onEvent = options.onEvent;
   const onToolRun = options.onToolRun;
   const finish = async (response: AgentResponse, includeSteps: boolean) =>
-    finishAgentRun(response, onEvent, includeSteps);
+    finishAgentRun(response, onEvent, includeSteps, options.emitFinalEvents !== false);
   const logger = createLogger(requestId);
   const startedAt = Date.now();
   let loopFinishedLogged = false;
@@ -706,7 +782,6 @@ export async function runAgent(
       readOnly: preparedConversationContext.sessionContext.readOnly === true,
     }).map((tool) => tool.name),
   };
-
   const steps: AgentStep[] = [];
   const pushStep = async (step: AgentStep) => {
     steps.push(step);
@@ -718,6 +793,12 @@ export async function runAgent(
   };
 
   const perception = perceive(context);
+  const requiredValidations =
+    context.sessionContext.requiredValidations?.length
+      ? context.sessionContext.requiredValidations
+      : extractRequiredValidations(perception.goal);
+  const ledger = createRunLedger(perception.goal, requiredValidations);
+  context.sessionContext = withLedgerSessionContext(context.sessionContext, ledger);
   await pushStep(perception.step);
 
   if (!options.disableTaskPlanning && context.sessionContext.sessionId) {
@@ -734,6 +815,8 @@ export async function runAgent(
       const taskPlanResponse = await runTaskPlanFlow({
         context,
         goal: perception.goal,
+        ledger,
+        onToolRun,
         pushStep,
         sessionId: context.sessionContext.sessionId,
         steps,
@@ -792,11 +875,52 @@ export async function runAgent(
 
       return finishWithLogging(
         {
-          message: createMessage(reply.content, reply.reasoning_content),
-          sessionContext:
+          message: createGroundedFinalMessage({
+            content: reply.content,
+            goal: perception.goal,
+            ledger,
+            reasoningContent: reply.reasoning_content,
+          }),
+          sessionContext: withLedgerSessionContext(
             toolRuns.length === 0
               ? context.sessionContext
               : buildNextSessionContext(context.sessionContext, toolRuns),
+            ledger,
+          ),
+          steps,
+        },
+        false,
+        toolRuns.length,
+      );
+    }
+
+    if (
+      isFileModificationRequest(perception.goal) &&
+      !ledger.appliedOrDraftedWrite &&
+      ledger.readCount > 0 &&
+      hasSafeCommandToolName(thought.toolName) &&
+      toolRuns.length + 1 >= maxToolCalls
+    ) {
+      await pushStep(
+        createStep(
+          `act-${roundNumber}`,
+          "Act",
+          "Stop before spending the final tool call on validation because no file change has been drafted or applied yet.",
+        ),
+      );
+
+      return finishWithLogging(
+        {
+          message: createGroundedFinalMessage({
+            content:
+              "I found code context for this edit request, but I did not modify files before the tool budget was exhausted.",
+            goal: perception.goal,
+            ledger,
+          }),
+          sessionContext: withLedgerSessionContext(
+            buildNextSessionContext(context.sessionContext, toolRuns),
+            ledger,
+          ),
           steps,
         },
         false,
@@ -852,6 +976,7 @@ export async function runAgent(
     }
 
     toolRuns.push(toolRun);
+    recordLedgerToolRun(ledger, perception.goal, toolRun);
     await onToolRun?.(toolRun);
 
     await pushStep(
@@ -872,8 +997,9 @@ export async function runAgent(
         context.sessionContext,
         toolRuns,
       );
+      const groundedSessionContext = withLedgerSessionContext(nextSessionContext, ledger);
       const autoApprovalResult = await handleAutoWriteApproval(
-        nextSessionContext,
+        groundedSessionContext,
         toolRun.result.draft ?? null,
       );
 
@@ -892,7 +1018,7 @@ export async function runAgent(
       return finishWithLogging(
         {
           message: createMessage(immediateOutcome.message),
-          sessionContext: nextSessionContext,
+          sessionContext: groundedSessionContext,
           steps,
         },
         false,
@@ -930,8 +1056,16 @@ export async function runAgent(
 
       return finishWithLogging(
         {
-          message: createMessage(finalReply.content, finalReply.reasoning_content),
-          sessionContext: buildNextSessionContext(context.sessionContext, toolRuns),
+          message: createGroundedFinalMessage({
+            content: finalReply.content,
+            goal: perception.goal,
+            ledger,
+            reasoningContent: finalReply.reasoning_content,
+          }),
+          sessionContext: withLedgerSessionContext(
+            buildNextSessionContext(context.sessionContext, toolRuns),
+            ledger,
+          ),
           steps,
         },
         false,
@@ -956,8 +1090,16 @@ export async function runAgent(
 
       return finishWithLogging(
         {
-          message: createMessage(finalReply.content, finalReply.reasoning_content),
-          sessionContext: buildNextSessionContext(context.sessionContext, toolRuns),
+          message: createGroundedFinalMessage({
+            content: finalReply.content,
+            goal: perception.goal,
+            ledger,
+            reasoningContent: finalReply.reasoning_content,
+          }),
+          sessionContext: withLedgerSessionContext(
+            buildNextSessionContext(context.sessionContext, toolRuns),
+            ledger,
+          ),
           steps,
         },
         false,

--- a/src/lib/agent/run-ledger.ts
+++ b/src/lib/agent/run-ledger.ts
@@ -1,0 +1,125 @@
+import {
+  classifySafeCommandIntent,
+  extractRequiredValidations,
+  getSafeCommandParts,
+  isSameCommand,
+  type CommandIntent,
+  type RequiredValidation,
+} from "./intent";
+import type { ToolRun } from "./tool-run-types";
+
+export type RunLedger = {
+  appliedOrDraftedWrite: boolean;
+  commandRuns: Array<{
+    args: string[];
+    command: string;
+    intent: CommandIntent;
+    ok: boolean;
+    toolCallId: string;
+  }>;
+  readCount: number;
+  requiredValidations: RequiredValidation[];
+  toolRuns: ToolRun[];
+  writePaths: string[];
+};
+
+export function createRunLedger(task: string, existingRequiredValidations: RequiredValidation[] = []): RunLedger {
+  const extracted = extractRequiredValidations(task);
+  const validations = existingRequiredValidations.length > 0 ? existingRequiredValidations : extracted;
+
+  return {
+    appliedOrDraftedWrite: false,
+    commandRuns: [],
+    readCount: 0,
+    requiredValidations: validations.map((validation) => ({ ...validation })),
+    toolRuns: [],
+    writePaths: [],
+  };
+}
+
+export function recordLedgerToolRun(
+  ledger: RunLedger,
+  task: string,
+  toolRun: ToolRun,
+) {
+  ledger.toolRuns.push(toolRun);
+
+  if (toolRun.name === "read_file" && toolRun.result.ok) {
+    ledger.readCount += 1;
+  }
+
+  if ((toolRun.name === "write_file" || toolRun.name === "replace_text") && toolRun.result.draft) {
+    ledger.appliedOrDraftedWrite = true;
+    ledger.writePaths.push(toolRun.result.draft.path);
+  }
+
+  if (toolRun.name !== "safe_command") {
+    return;
+  }
+
+  const command = getSafeCommandParts(toolRun.input);
+  if (!command) {
+    return;
+  }
+
+  const intent = classifySafeCommandIntent(toolRun.input, task, ledger.appliedOrDraftedWrite);
+  ledger.commandRuns.push({
+    ...command,
+    intent,
+    ok: toolRun.result.ok,
+    toolCallId: toolRun.toolCallId,
+  });
+
+  for (const validation of ledger.requiredValidations) {
+    if (!isSameCommand(command, validation)) {
+      continue;
+    }
+
+    if (toolRun.result.ok) {
+      validation.satisfiedAt = toolRun.finishedAt ?? Date.now();
+      validation.satisfiedByToolCallId = toolRun.toolCallId;
+      validation.lastFailure = undefined;
+    } else {
+      validation.lastFailure = toolRun.result.content;
+    }
+  }
+}
+
+export function getMissingRequiredValidations(ledger: RunLedger) {
+  return ledger.requiredValidations.filter(
+    (validation) => !validation.satisfiedByToolCallId,
+  );
+}
+
+export function formatGroundingSummary(ledger: RunLedger) {
+  const lines = ["Execution ledger:"];
+  const uniqueWritePaths = [...new Set(ledger.writePaths)];
+
+  lines.push(
+    uniqueWritePaths.length > 0
+      ? `- Drafted/applied file changes: ${uniqueWritePaths.join(", ")}`
+      : "- Drafted/applied file changes: none",
+  );
+
+  if (ledger.commandRuns.length > 0) {
+    lines.push("- Commands run:");
+    for (const commandRun of ledger.commandRuns) {
+      lines.push(
+        `  - ${commandRun.command} ${commandRun.args.join(" ")}: ${commandRun.ok ? "passed" : "failed"} (${commandRun.intent})`,
+      );
+    }
+  } else {
+    lines.push("- Commands run: none");
+  }
+
+  if (ledger.requiredValidations.length > 0) {
+    const missing = getMissingRequiredValidations(ledger);
+    lines.push(
+      missing.length === 0
+        ? "- Required validations: all satisfied"
+        : `- Required validations still missing or failed: ${missing.map((validation) => validation.label).join(", ")}`,
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/src/lib/agent/task-planner.ts
+++ b/src/lib/agent/task-planner.ts
@@ -92,6 +92,10 @@ export async function planTask(goal: string, context: AgentContext) {
         "You break a coding-agent task into a short ordered subtask list.",
         "Return only valid JSON with this exact shape: {\"subtasks\": string[]}.",
         "Each subtask must be independently runnable by the same agent.",
+        "Prefix each subtask with one of: [analyze], [implement], or [validate].",
+        "[analyze] subtasks must inspect files with read_file, tree_files, or search_text before running commands.",
+        "[implement] subtasks must apply code changes with replace_text or write_file when exact edits are known.",
+        "[validate] subtasks should run the required validation commands.",
         "Keep subtasks concrete and outcome-focused.",
         "Do not include a subtask that only says to report back.",
         "Prefer 2 to 5 subtasks.",
@@ -131,6 +135,7 @@ export async function runSubtask(
     `Current subtask: ${subtask.description}`,
     "",
     "Complete only the current subtask. Use the existing automatic loop. Do not re-plan the parent task.",
+    "Tool discipline: if this is an [analyze] subtask, inspect files first and do not run validation commands as the first action. If this is an [implement] subtask and exact edits are known, use replace_text or write_file. If this is a [validate] subtask, run the requested validation command.",
   ].join("\n");
 
   return runAgent(task, [], sessionContext, `subtask_${subtask.id}`, {

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+
+export function requireAgentApiAuth(request: Request) {
+  const agentApiSecret = process.env.AGENT_API_SECRET?.trim();
+  const authorization = request.headers.get("authorization");
+
+  if (!agentApiSecret) {
+    console.warn(
+      "AGENT_API_SECRET is not set. Rejecting API requests until server-side auth is configured.",
+    );
+
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  if (authorization !== `Bearer ${agentApiSecret}`) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  return null;
+}

--- a/src/lib/db/store.ts
+++ b/src/lib/db/store.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 import type {
   AgentSessionContext,
@@ -115,6 +115,24 @@ function mapProjectSummary(row: ProjectRow, sessions: SessionSummary[]): Project
   };
 }
 
+function resolveLikelyWorkspaceRoot(workspacePath: string) {
+  if (existsSync(path.join(workspacePath, "package.json"))) {
+    return workspacePath;
+  }
+
+  const childProjectPaths = readdirSync(workspacePath)
+    .map((entryName) => path.join(workspacePath, entryName))
+    .filter((childPath) => {
+      try {
+        return statSync(childPath).isDirectory() && existsSync(path.join(childPath, "package.json"));
+      } catch {
+        return false;
+      }
+    });
+
+  return childProjectPaths.length === 1 ? childProjectPaths[0] : workspacePath;
+}
+
 function mapSubtask(row: SubtaskRow): SubtaskRecord {
   return {
     createdAt: row.created_at,
@@ -222,7 +240,9 @@ export function createProject(input: {
   const db = getDb();
   const timestamp = now();
   const projectId = createId("proj");
-  const workspacePath = normalizeWorkspacePath(input.workspacePath);
+  const workspacePath = resolveLikelyWorkspaceRoot(
+    normalizeWorkspacePath(input.workspacePath),
+  );
   const name = input.name.trim() || path.basename(workspacePath) || "Untitled project";
 
   db.prepare(
@@ -329,6 +349,32 @@ export function updateSessionState(
       timestamp,
       sessionId,
     );
+}
+
+export function updateSessionSettings(
+  sessionId: string,
+  settings: {
+    autoApprove?: boolean;
+  },
+) {
+  const session = getSession(sessionId);
+
+  if (!session) {
+    throw new Error("Session was not found.");
+  }
+
+  const nextContext: AgentSessionContext = {
+    ...session.sessionContext,
+    autoApprove:
+      settings.autoApprove === undefined
+        ? session.sessionContext.autoApprove === true
+        : settings.autoApprove === true,
+    sessionId,
+  };
+
+  updateSessionState(sessionId, nextContext, session.steps);
+
+  return getSession(sessionId);
 }
 
 function touchSession(sessionId: string, timestamp = now()) {

--- a/src/lib/tools/safe-command.ts
+++ b/src/lib/tools/safe-command.ts
@@ -12,6 +12,7 @@ import { getWorkspaceRoot, resolveWorkspacePath } from "./workspace-path";
 
 const execFileAsync = promisify(execFile);
 const MAX_OUTPUT_LENGTH = 8_000;
+const SAFE_COMMAND_TIMEOUT_MS = 120_000;
 const BLOCKED_COMMANDS = new Set([
   "bash",
   "cmd",
@@ -608,6 +609,7 @@ async function executeSafeCommand(input: ToolExecutionInput): Promise<ToolResult
       {
         cwd: getWorkspaceRoot(),
         maxBuffer: 1024 * 1024,
+        timeout: SAFE_COMMAND_TIMEOUT_MS,
         windowsHide: true,
       },
     );

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -22,6 +22,16 @@ export type PendingWorkspaceSwitch = {
   workspacePath: string;
 };
 
+export type RequiredValidation = {
+  args: string[];
+  command: string;
+  id: string;
+  label: string;
+  lastFailure?: string;
+  satisfiedAt?: number;
+  satisfiedByToolCallId?: string;
+};
+
 export type AgentSessionContext = {
   autoApprove?: boolean;
   conversationSummary?: string | null;
@@ -34,6 +44,7 @@ export type AgentSessionContext = {
   pendingWorkspaceSwitch?: PendingWorkspaceSwitch | null;
   projectId?: string | null;
   readOnly?: boolean | null;
+  requiredValidations?: RequiredValidation[];
   sessionId?: string | null;
   workspacePathOverride?: string | null;
 };

--- a/test/agent-reliability.test.ts
+++ b/test/agent-reliability.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  classifySafeCommandIntent,
+  extractRequiredValidations,
+  isFileModificationRequest,
+  looksLikeManualEditInstructions,
+  parseSessionSettingCommand,
+} from "../src/lib/agent/intent";
+import {
+  createRunLedger,
+  getMissingRequiredValidations,
+  recordLedgerToolRun,
+} from "../src/lib/agent/run-ledger";
+import type { ToolRun } from "../src/lib/agent/tool-run-types";
+
+function toolRun(partial: Partial<ToolRun>): ToolRun {
+  return {
+    assistantMessage: {
+      role: "assistant",
+      content: null,
+    },
+    input: {},
+    inputText: "{}",
+    name: "read_file",
+    result: {
+      ok: true,
+      content: "ok",
+    },
+    tool: {
+      name: "read_file",
+      description: "",
+      inputSchema: {
+        type: "object",
+        properties: {},
+      },
+      async execute() {
+        return {
+          ok: true,
+          content: "ok",
+        };
+      },
+    },
+    toolCallId: "tool-call-1",
+    ...partial,
+  };
+}
+
+test("Chinese edit and manual-instruction intent is detected", () => {
+  assert.equal(isFileModificationRequest("请修好这些测试失败"), true);
+  assert.equal(isFileModificationRequest("应用修复并运行 npm test"), true);
+  assert.equal(isFileModificationRequest("你倒是修啊！！！"), true);
+  assert.equal(looksLikeManualEditInstructions("请手动把 a 改成 b"), true);
+});
+
+test("autoApprove text commands parse as real setting commands", () => {
+  assert.deepEqual(parseSessionSettingCommand("autoApprove: true"), {
+    autoApprove: true,
+    kind: "autoApprove",
+  });
+  assert.deepEqual(parseSessionSettingCommand("打开全自动模式"), {
+    autoApprove: true,
+    kind: "autoApprove",
+  });
+  assert.deepEqual(parseSessionSettingCommand("关闭自动批准"), {
+    autoApprove: false,
+    kind: "autoApprove",
+  });
+});
+
+test("required npm validations are extracted from mixed-language tasks", () => {
+  const validations = extractRequiredValidations(
+    "修完后运行 npm test、npm run build、npm run lint，全部通过才算完成",
+  );
+
+  assert.deepEqual(
+    validations.map((validation) => validation.label),
+    ["npm test", "npm run build", "npm run lint"],
+  );
+});
+
+test("failing tests before edits are diagnostic, after edits are validation", () => {
+  const input = {
+    command: "npm",
+    args: ["test"],
+  };
+
+  assert.equal(
+    classifySafeCommandIntent(input, "fix failing tests", false),
+    "diagnostic",
+  );
+  assert.equal(
+    classifySafeCommandIntent(input, "fix failing tests", true),
+    "validation",
+  );
+});
+
+test("run ledger satisfies required validations only with matching successful commands", () => {
+  const ledger = createRunLedger("run npm test and npm run build");
+
+  recordLedgerToolRun(
+    ledger,
+    "run npm test and npm run build",
+    toolRun({
+      input: {
+        command: "npm",
+        args: ["test"],
+      },
+      inputText: '{"command":"npm","args":["test"]}',
+      name: "safe_command",
+      result: {
+        ok: true,
+        content: "passed",
+      },
+      toolCallId: "test-run",
+    }),
+  );
+
+  assert.deepEqual(
+    getMissingRequiredValidations(ledger).map((validation) => validation.label),
+    ["npm run build"],
+  );
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -13,6 +13,10 @@
     "src/lib/tools/safe-command.ts",
     "src/lib/tools/types.ts",
     "src/lib/tools/workspace-path.ts",
+    "src/lib/agent/intent.ts",
+    "src/lib/agent/run-ledger.ts",
+    "src/lib/agent/tool-args.ts",
+    "src/lib/agent/tool-run-types.ts",
     "test/**/*.ts"
   ]
 }


### PR DESCRIPTION
## Summary

This PR implements the first reliability pass from the Thrush upgrade plan:

- adds UTF-8-safe intent helpers for edit requests, autoApprove commands, required validation extraction, and command intent classification
- adds a run-local ledger that tracks reads, write drafts, safe_command runs, and required validation satisfaction
- grounds final answers so Thrush cannot claim file edits or validation success without matching tool evidence
- prevents spending the final tool call on validation for edit tasks when no write has happened yet
- treats early failing tests as diagnostic evidence for repair tasks instead of immediately blocking subtasks
- forwards subtask tool runs to the parent route callback so SQLite tool history is not lost
- adds a real autoApprove settings API and UI toggle
- moves API Bearer auth into a shared helper and applies it to workbench/session routes
- fixes stream final-event ownership so stream mode emits the persisted assistant message and done event after DB write
- adds a safe_command timeout and smarter nested workspace root detection

## Validation

- npx tsc --noEmit
- npm test
- npm run lint
- npm run build

## Notes

This is a broad first-pass reliability PR, not the full eight-PR decomposition. It intentionally keeps DeepSeek thinking disabled and does not hardcode Level 3 target fixes.